### PR TITLE
Enable the em100pro spi hyperterminal console

### DIFF
--- a/ipxact/NVM.xml
+++ b/ipxact/NVM.xml
@@ -30,6 +30,13 @@
                     <ipxact:size>32</ipxact:size>
                     <ipxact:volatile>true</ipxact:volatile>
                     <ipxact:field>
+                        <ipxact:name>Reset</ipxact:name>
+                        <ipxact:description>When set, the entire NVM state machine is reset. This bit is self- clearing.</ipxact:description>
+                        <ipxact:bitOffset>1</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
+                    <ipxact:field>
                         <ipxact:name>Done</ipxact:name>
                         <ipxact:description>Sequence completion bit that is asserted when the command requested by assertion of the doit bit has completed.</ipxact:description>
                         <ipxact:bitOffset>3</ipxact:bitOffset>
@@ -93,6 +100,34 @@
                     <!-- LINK: registerDefinitionGroup: see 6.11.3, Register definition group -->
                     <ipxact:size>32</ipxact:size>
                     <ipxact:volatile>true</ipxact:volatile>
+                    <ipxact:field>
+                        <ipxact:name>SCLK Output Value</ipxact:name>
+                        <ipxact:description>When in bit-bang mode, this bit controls the SCLK output value.</ipxact:description>
+                        <ipxact:bitOffset>2</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
+                    <ipxact:field>
+                        <ipxact:name>CSb Output Value</ipxact:name>
+                        <ipxact:description>When in bit-bang mode, this bit controls the CSb output value.</ipxact:description>
+                        <ipxact:bitOffset>3</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
+                    <ipxact:field>
+                        <ipxact:name>SI Output Value</ipxact:name>
+                        <ipxact:description>When in bit-bang mode, this bit controls the SI output value.</ipxact:description>
+                        <ipxact:bitOffset>4</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
+                    <ipxact:field>
+                        <ipxact:name>SO Output Value</ipxact:name>
+                        <ipxact:description>When in bit-bang mode, this bit controls the SO output value.</ipxact:description>
+                        <ipxact:bitOffset>5</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
                 </ipxact:register>
                 <ipxact:register>
                     <ipxact:name>ADDR</ipxact:name>
@@ -101,6 +136,34 @@
                     <!-- LINK: registerDefinitionGroup: see 6.11.3, Register definition group -->
                     <ipxact:size>32</ipxact:size>
                     <ipxact:volatile>true</ipxact:volatile>
+                    <ipxact:field>
+                        <ipxact:name>SCLK Output Disable</ipxact:name>
+                        <ipxact:description>When in bit-bang mode, this bit controls the SCLK output enable.</ipxact:description>
+                        <ipxact:bitOffset>2</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
+                    <ipxact:field>
+                        <ipxact:name>CSb Output Disable</ipxact:name>
+                        <ipxact:description>When in bit-bang mode, this bit controls the CSb output enable.</ipxact:description>
+                        <ipxact:bitOffset>3</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
+                    <ipxact:field>
+                        <ipxact:name>SI Output Disable</ipxact:name>
+                        <ipxact:description>When in bit-bang mode, this bit controls the SI output enable.</ipxact:description>
+                        <ipxact:bitOffset>4</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
+                    <ipxact:field>
+                        <ipxact:name>SO Output Disable</ipxact:name>
+                        <ipxact:description>When in bit-bang mode, this bit controls the SO output enable.</ipxact:description>
+                        <ipxact:bitOffset>5</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
                 </ipxact:register>
                 <ipxact:register>
                     <ipxact:name>READ</ipxact:name>
@@ -109,6 +172,34 @@
                     <!-- LINK: registerDefinitionGroup: see 6.11.3, Register definition group -->
                     <ipxact:size>32</ipxact:size>
                     <ipxact:volatile>true</ipxact:volatile>
+                    <ipxact:field>
+                        <ipxact:name>SCLK Input Value</ipxact:name>
+                        <ipxact:description>When in bit-bang mode, this bit reads the current SCLK input value.</ipxact:description>
+                        <ipxact:bitOffset>2</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
+                    <ipxact:field>
+                        <ipxact:name>CSb Input Value</ipxact:name>
+                        <ipxact:description>When in bit-bang mode, this bit reads the current CSb input value.</ipxact:description>
+                        <ipxact:bitOffset>3</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
+                    <ipxact:field>
+                        <ipxact:name>SI Input Value</ipxact:name>
+                        <ipxact:description>When in bit-bang mode, this bit reads the current SI input value.</ipxact:description>
+                        <ipxact:bitOffset>4</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
+                    <ipxact:field>
+                        <ipxact:name>SO Input Value</ipxact:name>
+                        <ipxact:description>When in bit-bang mode, this bit reads the current SO input value.</ipxact:description>
+                        <ipxact:bitOffset>5</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
                 </ipxact:register>
                 <ipxact:register>
                     <ipxact:name>NVM_CFG_1</ipxact:name>
@@ -132,6 +223,27 @@
                         <ipxact:access>read-write</ipxact:access>
                     </ipxact:field>
                     <ipxact:field>
+                        <ipxact:name>Pass Mode</ipxact:name>
+                        <ipxact:description>Enable pass-thorough mode to the byte level SPI and SEE state machines.</ipxact:description>
+                        <ipxact:bitOffset>2</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
+                    <ipxact:field>
+                        <ipxact:name>Bitbang Mode</ipxact:name>
+                        <ipxact:description>Enable bit-bang mode to control pins.</ipxact:description>
+                        <ipxact:bitOffset>3</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
+                    <ipxact:field>
+                        <ipxact:name>Status Bit</ipxact:name>
+                        <ipxact:description>Bit Offset in status command response to interpret as the ready flag.</ipxact:description>
+                        <ipxact:bitOffset>4</ipxact:bitOffset>
+                        <ipxact:bitWidth>3</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
+                    <ipxact:field>
                         <ipxact:name>SPI CLK DIV</ipxact:name>
                         <ipxact:description>The equation to calculate the clock freq. for SCK is: CORE_CLK / ((SPI_CLK_DIV + 1) * 2)</ipxact:description>
                         <ipxact:bitOffset>7</ipxact:bitOffset>
@@ -147,7 +259,7 @@
                     </ipxact:field>
                     <ipxact:field>
                         <ipxact:name>Flash Size</ipxact:name>
-                        <ipxact:description></ipxact:description>
+                        <ipxact:description>Enables 1-Mbit devices as opposed to 512 Kbit. At CORE reset, this pin is set to the value of the SO pin.</ipxact:description>
                         <ipxact:bitOffset>25</ipxact:bitOffset>
                         <ipxact:bitWidth>1</ipxact:bitWidth>
                         <ipxact:access>read-write</ipxact:access>

--- a/libs/NVRam/CMakeLists.txt
+++ b/libs/NVRam/CMakeLists.txt
@@ -46,8 +46,10 @@ project(NVRam)
 
 SET(SOURCES
     nvm.c
+    EM100.c
     crc.c
     include/NVRam.h
+    include/EM100.h
 )
 
 # Host Simulation library

--- a/libs/NVRam/EM100.c
+++ b/libs/NVRam/EM100.c
@@ -1,0 +1,187 @@
+////////////////////////////////////////////////////////////////////////////////
+///
+/// @file       EM100.c
+///
+/// @project
+///
+/// @brief      EM100 Debug Routines
+///
+////////////////////////////////////////////////////////////////////////////////
+///
+////////////////////////////////////////////////////////////////////////////////
+///
+/// @copyright Copyright (c) 2019, Evan Lojewski
+/// @cond
+///
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without
+/// modification, are permitted provided that the following conditions are met:
+/// 1. Redistributions of source code must retain the above copyright notice,
+/// this list of conditions and the following disclaimer.
+/// 2. Redistributions in binary form must reproduce the above copyright notice,
+/// this list of conditions and the following disclaimer in the documentation
+/// and/or other materials provided with the distribution.
+/// 3. Neither the name of the copyright holder nor the
+/// names of its contributors may be used to endorse or promote products
+/// derived from this software without specific prior written permission.
+///
+////////////////////////////////////////////////////////////////////////////////
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+/// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+/// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+/// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+/// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+/// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+/// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+/// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+/// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// @endcond
+////////////////////////////////////////////////////////////////////////////////
+#include "bcm5719_NVM.h"
+
+#include <NVRam.h>
+
+// #define ENABLE_CONSOLE
+#undef ENABLE_CONSOLE
+
+#if ENABLE_CONSOLE
+void NVRam_EM100_enableConsole(void);
+void NVRam_EM100_disableConsole(void);
+#endif /* ENABLE_CONSOLE */
+
+#define EM100_CONSOLE_WRITE_COMMAND (0x11)
+
+#define EM100_CMD_GET_UFIFO_LEN (0xB1)
+#define EM100_CMD_GET_DFIFO_LEN (0xB2)
+#define EM100_CMD_WRITE_UFIFO (0xC0)
+#define EM100_CMD_READ_DFIFO (0xD0)
+#define EM100_CMD_EXIT_CONSOLE (0xE0)
+
+#define EM100_MSG_STRING (0x05)
+#define EM100_MSG_SIG (0x47364440)
+
+uint8_t gEM100Packet[64] = {
+    EM100_CONSOLE_WRITE_COMMAND,  /* 0: SPI COmmand */
+    0x00,                         /* 1: Reserved */
+    EM100_CMD_WRITE_UFIFO,        /* 2: EM100 COmmand */
+    0xFF & (EM100_MSG_SIG),       /* 3: EM100_MSG_SIG */
+    0xFF & (EM100_MSG_SIG >> 8),  /* 4: EM100_MSG_SIG */
+    0xFF & (EM100_MSG_SIG >> 16), /* 5: EM100_MSG_SIG */
+    0xFF & (EM100_MSG_SIG >> 24), /* 6: EM100_MSG_SIG */
+    EM100_MSG_STRING,             /* 7: Message Type */
+    0,                            /* 8: Message Length */
+};
+#define EM100_PACKET_MSG_LEN (8u)
+#define EM100_PACKET_BUFFER_OFFSET (9u)
+#define EM100_MAX_BUFFER_LEN (sizeof(gEM100Packet) - EM100_PACKET_BUFFER_OFFSET)
+
+void NVRAM_EM100_send_byte(uint8_t byte)
+{
+    RegNVMWrite_t nvm_write;
+    nvm_write.r32 = 0;
+
+    for (int i = 7; i >= 0; i--)
+    {
+        // Setup the SI value
+        nvm_write.bits.SCLKOutputValue = 0;
+        nvm_write.bits.SIOutputValue = (byte & (1 << i)) ? 1 : 0;
+        NVM.Write.r32 = nvm_write.r32;
+
+        // Clock data out.
+        nvm_write.bits.SCLKOutputValue = 1;
+        NVM.Write.r32 = nvm_write.r32;
+    }
+
+    // Final clock edge
+    nvm_write.bits.SCLKOutputValue = 0;
+    nvm_write.bits.SIOutputValue = 0;
+    NVM.Write.r32 = nvm_write.r32;
+}
+
+void NVRam_EM100_writeBytes(uint8_t bytes[], size_t num_bytes)
+{
+    // Aquire the lock
+    NVRam_acquireLock();
+    NVRam_enable();
+
+    // Save defaults and set sane values
+    RegNVMNvmCfg1_t cfg1_orig;
+    RegNVMNvmCfg1_t cfg1_bitbang;
+    cfg1_orig.r32 = NVM.NvmCfg1.r32;
+    cfg1_bitbang.r32 = cfg1_orig.r32;
+    cfg1_bitbang.bits.BitbangMode = 1;
+
+    // Drive the SCLK, CSb and MOSI lines
+    RegNVMAddr_t nvm_od;
+    nvm_od.r32 = 0xffffff;             // All Input
+    nvm_od.bits.SCLKOutputDisable = 0; // Drive SCLK
+    nvm_od.bits.CSbOutputDisable = 0;  // Drive CSb
+    nvm_od.bits.SIOutputDisable = 0;   // Drive MOSI
+
+    RegNVMWrite_t nvm_write;
+
+    NVM.Addr.r32 = nvm_od.r32;
+    NVM.Write.r32 = nvm_write.r32;
+    // Enable Bitbang mode
+    NVM.NvmCfg1.r32 = cfg1_bitbang.r32;
+
+    for (int i = 0; i < num_bytes; i++)
+    {
+        NVRAM_EM100_send_byte(bytes[i]);
+    }
+
+    // Restore Cfg1.
+    NVM.NvmCfg1.r32 = cfg1_orig.r32;
+
+    NVRam_disable();
+    NVRam_releaseLock();
+}
+
+void NVRam_EM100_putchar(char c)
+{
+    int used_buffer = gEM100Packet[EM100_PACKET_MSG_LEN] + 1;
+
+    gEM100Packet[used_buffer + EM100_PACKET_BUFFER_OFFSET - 1] = c;
+    gEM100Packet[EM100_PACKET_MSG_LEN] = used_buffer;
+
+    // Flush if the buffer is full or if we reached the end of a line
+    if (('\n' == c) || (used_buffer >= EM100_MAX_BUFFER_LEN))
+    {
+#if ENABLE_CONSOLE
+        NVRam_EM100_enableConsole();
+#endif
+        NVRam_EM100_writeBytes(gEM100Packet, EM100_PACKET_BUFFER_OFFSET + used_buffer);
+        // Mark buffer as empty
+        gEM100Packet[EM100_PACKET_MSG_LEN] = 0;
+#if ENABLE_CONSOLE
+        NVRam_EM100_disableConsole();
+#endif
+    }
+}
+
+#if ENABLE_CONSOLE
+void NVRam_EM100_enableConsole(void)
+{
+    uint8_t packet_AA[] = { EM100_CONSOLE_WRITE_COMMAND, 0x00, 0xAA, 0xAA, 0x00 };
+    uint8_t packet_55[] = { EM100_CONSOLE_WRITE_COMMAND, 0x00, 0x55, 0x55, 0x00 };
+
+    NVRam_EM100_writeBytes(packet_AA, sizeof(packet_AA));
+    NVRam_EM100_writeBytes(packet_55, sizeof(packet_AA));
+    NVRam_EM100_writeBytes(packet_AA, sizeof(packet_AA));
+}
+
+void NVRam_EM100_disableConsole(void)
+{
+    uint8_t packet_exit_console[] = {
+        EM100_CONSOLE_WRITE_COMMAND,
+        0x00,
+        EM100_CMD_EXIT_CONSOLE,
+        0x00,
+    };
+    NVRam_EM100_writeBytes(packet_exit_console, sizeof(packet_exit_console));
+}
+#endif /* ENABLE_CONSOLE */

--- a/libs/NVRam/bcm5719_NVM.h
+++ b/libs/NVRam/bcm5719_NVM.h
@@ -82,6 +82,10 @@ typedef uint32_t BCM5719_NVM_H_uint32_t;
 #define REG_NVM_SIZE (sizeof(NVM_t))
 
 #define REG_NVM_COMMAND ((volatile BCM5719_NVM_H_uint32_t*)0xc0007000) /*  */
+#define     NVM_COMMAND_RESET_SHIFT 1u
+#define     NVM_COMMAND_RESET_MASK  0x2u
+#define GET_NVM_COMMAND_RESET(__reg__)  (((__reg__) & 0x2) >> 1u)
+#define SET_NVM_COMMAND_RESET(__val__)  (((__val__) << 1u) & 0x2u)
 #define     NVM_COMMAND_DONE_SHIFT 3u
 #define     NVM_COMMAND_DONE_MASK  0x8u
 #define GET_NVM_COMMAND_DONE(__reg__)  (((__reg__) & 0x8) >> 3u)
@@ -123,7 +127,11 @@ typedef register_container RegNVMCommand_t {
     BITFIELD_BEGIN(BCM5719_NVM_H_uint32_t, bits)
 #if defined(__LITTLE_ENDIAN__)
         /** @brief Padding */
-        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_2_0, 0, 3)
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_0_0, 0, 1)
+        /** @brief When set, the entire NVM state machine is reset. This bit is self- clearing. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, Reset, 1, 1)
+        /** @brief Padding */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_2_2, 2, 1)
         /** @brief Sequence completion bit that is asserted when the command requested by assertion of the doit bit has completed. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, Done, 3, 1)
         /** @brief Command from software to start the defined command. The done bit must be clear before setting this bit. This bit is self clearing and will remain set while the command is active. */
@@ -166,7 +174,11 @@ typedef register_container RegNVMCommand_t {
         /** @brief Sequence completion bit that is asserted when the command requested by assertion of the doit bit has completed. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, Done, 3, 1)
         /** @brief Padding */
-        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_2_0, 0, 3)
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_2_2, 2, 1)
+        /** @brief When set, the entire NVM state machine is reset. This bit is self- clearing. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, Reset, 1, 1)
+        /** @brief Padding */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_0_0, 0, 1)
 #else
 #error Unknown Endian
 #endif
@@ -182,6 +194,8 @@ typedef register_container RegNVMCommand_t {
     {
         /** @brief constructor for @ref NVM_t.Command. */
         r32.setName("Command");
+        bits.Reset.setBaseRegister(&r32);
+        bits.Reset.setName("Reset");
         bits.Done.setBaseRegister(&r32);
         bits.Done.setName("Done");
         bits.Doit.setBaseRegister(&r32);
@@ -208,10 +222,59 @@ typedef register_container RegNVMCommand_t {
 } RegNVMCommand_t;
 
 #define REG_NVM_WRITE ((volatile BCM5719_NVM_H_uint32_t*)0xc0007008) /* 32bits of write data are used when write commands are executed. */
+#define     NVM_WRITE_SCLK_OUTPUT_VALUE_SHIFT 2u
+#define     NVM_WRITE_SCLK_OUTPUT_VALUE_MASK  0x4u
+#define GET_NVM_WRITE_SCLK_OUTPUT_VALUE(__reg__)  (((__reg__) & 0x4) >> 2u)
+#define SET_NVM_WRITE_SCLK_OUTPUT_VALUE(__val__)  (((__val__) << 2u) & 0x4u)
+#define     NVM_WRITE_CSB_OUTPUT_VALUE_SHIFT 3u
+#define     NVM_WRITE_CSB_OUTPUT_VALUE_MASK  0x8u
+#define GET_NVM_WRITE_CSB_OUTPUT_VALUE(__reg__)  (((__reg__) & 0x8) >> 3u)
+#define SET_NVM_WRITE_CSB_OUTPUT_VALUE(__val__)  (((__val__) << 3u) & 0x8u)
+#define     NVM_WRITE_SI_OUTPUT_VALUE_SHIFT 4u
+#define     NVM_WRITE_SI_OUTPUT_VALUE_MASK  0x10u
+#define GET_NVM_WRITE_SI_OUTPUT_VALUE(__reg__)  (((__reg__) & 0x10) >> 4u)
+#define SET_NVM_WRITE_SI_OUTPUT_VALUE(__val__)  (((__val__) << 4u) & 0x10u)
+#define     NVM_WRITE_SO_OUTPUT_VALUE_SHIFT 5u
+#define     NVM_WRITE_SO_OUTPUT_VALUE_MASK  0x20u
+#define GET_NVM_WRITE_SO_OUTPUT_VALUE(__reg__)  (((__reg__) & 0x20) >> 5u)
+#define SET_NVM_WRITE_SO_OUTPUT_VALUE(__val__)  (((__val__) << 5u) & 0x20u)
+
 /** @brief Register definition for @ref NVM_t.Write. */
 typedef register_container RegNVMWrite_t {
     /** @brief 32bit direct register access. */
     BCM5719_NVM_H_uint32_t r32;
+
+    BITFIELD_BEGIN(BCM5719_NVM_H_uint32_t, bits)
+#if defined(__LITTLE_ENDIAN__)
+        /** @brief Padding */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_1_0, 0, 2)
+        /** @brief When in bit-bang mode, this bit controls the SCLK output value. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SCLKOutputValue, 2, 1)
+        /** @brief When in bit-bang mode, this bit controls the CSb output value. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, CSbOutputValue, 3, 1)
+        /** @brief When in bit-bang mode, this bit controls the SI output value. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SIOutputValue, 4, 1)
+        /** @brief When in bit-bang mode, this bit controls the SO output value. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SOOutputValue, 5, 1)
+        /** @brief Padding */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_31_6, 6, 26)
+#elif defined(__BIG_ENDIAN__)
+        /** @brief Padding */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_31_6, 6, 26)
+        /** @brief When in bit-bang mode, this bit controls the SO output value. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SOOutputValue, 5, 1)
+        /** @brief When in bit-bang mode, this bit controls the SI output value. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SIOutputValue, 4, 1)
+        /** @brief When in bit-bang mode, this bit controls the CSb output value. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, CSbOutputValue, 3, 1)
+        /** @brief When in bit-bang mode, this bit controls the SCLK output value. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SCLKOutputValue, 2, 1)
+        /** @brief Padding */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_1_0, 0, 2)
+#else
+#error Unknown Endian
+#endif
+    BITFIELD_END(BCM5719_NVM_H_uint32_t, bits)
 #ifdef CXX_SIMULATOR
     /** @brief Register name for use with the simulator. */
     const char* getName(void) { return "Write"; }
@@ -223,6 +286,14 @@ typedef register_container RegNVMWrite_t {
     {
         /** @brief constructor for @ref NVM_t.Write. */
         r32.setName("Write");
+        bits.SCLKOutputValue.setBaseRegister(&r32);
+        bits.SCLKOutputValue.setName("SCLKOutputValue");
+        bits.CSbOutputValue.setBaseRegister(&r32);
+        bits.CSbOutputValue.setName("CSbOutputValue");
+        bits.SIOutputValue.setBaseRegister(&r32);
+        bits.SIOutputValue.setName("SIOutputValue");
+        bits.SOOutputValue.setBaseRegister(&r32);
+        bits.SOOutputValue.setName("SOOutputValue");
     }
     RegNVMWrite_t& operator=(const RegNVMWrite_t& other)
     {
@@ -233,10 +304,59 @@ typedef register_container RegNVMWrite_t {
 } RegNVMWrite_t;
 
 #define REG_NVM_ADDR ((volatile BCM5719_NVM_H_uint32_t*)0xc000700c) /* The 24 bit address for a read or write operation (must be 4 byte aligned). */
+#define     NVM_ADDR_SCLK_OUTPUT_DISABLE_SHIFT 2u
+#define     NVM_ADDR_SCLK_OUTPUT_DISABLE_MASK  0x4u
+#define GET_NVM_ADDR_SCLK_OUTPUT_DISABLE(__reg__)  (((__reg__) & 0x4) >> 2u)
+#define SET_NVM_ADDR_SCLK_OUTPUT_DISABLE(__val__)  (((__val__) << 2u) & 0x4u)
+#define     NVM_ADDR_CSB_OUTPUT_DISABLE_SHIFT 3u
+#define     NVM_ADDR_CSB_OUTPUT_DISABLE_MASK  0x8u
+#define GET_NVM_ADDR_CSB_OUTPUT_DISABLE(__reg__)  (((__reg__) & 0x8) >> 3u)
+#define SET_NVM_ADDR_CSB_OUTPUT_DISABLE(__val__)  (((__val__) << 3u) & 0x8u)
+#define     NVM_ADDR_SI_OUTPUT_DISABLE_SHIFT 4u
+#define     NVM_ADDR_SI_OUTPUT_DISABLE_MASK  0x10u
+#define GET_NVM_ADDR_SI_OUTPUT_DISABLE(__reg__)  (((__reg__) & 0x10) >> 4u)
+#define SET_NVM_ADDR_SI_OUTPUT_DISABLE(__val__)  (((__val__) << 4u) & 0x10u)
+#define     NVM_ADDR_SO_OUTPUT_DISABLE_SHIFT 5u
+#define     NVM_ADDR_SO_OUTPUT_DISABLE_MASK  0x20u
+#define GET_NVM_ADDR_SO_OUTPUT_DISABLE(__reg__)  (((__reg__) & 0x20) >> 5u)
+#define SET_NVM_ADDR_SO_OUTPUT_DISABLE(__val__)  (((__val__) << 5u) & 0x20u)
+
 /** @brief Register definition for @ref NVM_t.Addr. */
 typedef register_container RegNVMAddr_t {
     /** @brief 32bit direct register access. */
     BCM5719_NVM_H_uint32_t r32;
+
+    BITFIELD_BEGIN(BCM5719_NVM_H_uint32_t, bits)
+#if defined(__LITTLE_ENDIAN__)
+        /** @brief Padding */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_1_0, 0, 2)
+        /** @brief When in bit-bang mode, this bit controls the SCLK output enable. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SCLKOutputDisable, 2, 1)
+        /** @brief When in bit-bang mode, this bit controls the CSb output enable. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, CSbOutputDisable, 3, 1)
+        /** @brief When in bit-bang mode, this bit controls the SI output enable. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SIOutputDisable, 4, 1)
+        /** @brief When in bit-bang mode, this bit controls the SO output enable. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SOOutputDisable, 5, 1)
+        /** @brief Padding */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_31_6, 6, 26)
+#elif defined(__BIG_ENDIAN__)
+        /** @brief Padding */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_31_6, 6, 26)
+        /** @brief When in bit-bang mode, this bit controls the SO output enable. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SOOutputDisable, 5, 1)
+        /** @brief When in bit-bang mode, this bit controls the SI output enable. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SIOutputDisable, 4, 1)
+        /** @brief When in bit-bang mode, this bit controls the CSb output enable. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, CSbOutputDisable, 3, 1)
+        /** @brief When in bit-bang mode, this bit controls the SCLK output enable. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SCLKOutputDisable, 2, 1)
+        /** @brief Padding */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_1_0, 0, 2)
+#else
+#error Unknown Endian
+#endif
+    BITFIELD_END(BCM5719_NVM_H_uint32_t, bits)
 #ifdef CXX_SIMULATOR
     /** @brief Register name for use with the simulator. */
     const char* getName(void) { return "Addr"; }
@@ -248,6 +368,14 @@ typedef register_container RegNVMAddr_t {
     {
         /** @brief constructor for @ref NVM_t.Addr. */
         r32.setName("Addr");
+        bits.SCLKOutputDisable.setBaseRegister(&r32);
+        bits.SCLKOutputDisable.setName("SCLKOutputDisable");
+        bits.CSbOutputDisable.setBaseRegister(&r32);
+        bits.CSbOutputDisable.setName("CSbOutputDisable");
+        bits.SIOutputDisable.setBaseRegister(&r32);
+        bits.SIOutputDisable.setName("SIOutputDisable");
+        bits.SOOutputDisable.setBaseRegister(&r32);
+        bits.SOOutputDisable.setName("SOOutputDisable");
     }
     RegNVMAddr_t& operator=(const RegNVMAddr_t& other)
     {
@@ -258,10 +386,59 @@ typedef register_container RegNVMAddr_t {
 } RegNVMAddr_t;
 
 #define REG_NVM_READ ((volatile BCM5719_NVM_H_uint32_t*)0xc0007010) /* 32bits of read data are used when read commands are executed. */
+#define     NVM_READ_SCLK_INPUT_VALUE_SHIFT 2u
+#define     NVM_READ_SCLK_INPUT_VALUE_MASK  0x4u
+#define GET_NVM_READ_SCLK_INPUT_VALUE(__reg__)  (((__reg__) & 0x4) >> 2u)
+#define SET_NVM_READ_SCLK_INPUT_VALUE(__val__)  (((__val__) << 2u) & 0x4u)
+#define     NVM_READ_CSB_INPUT_VALUE_SHIFT 3u
+#define     NVM_READ_CSB_INPUT_VALUE_MASK  0x8u
+#define GET_NVM_READ_CSB_INPUT_VALUE(__reg__)  (((__reg__) & 0x8) >> 3u)
+#define SET_NVM_READ_CSB_INPUT_VALUE(__val__)  (((__val__) << 3u) & 0x8u)
+#define     NVM_READ_SI_INPUT_VALUE_SHIFT 4u
+#define     NVM_READ_SI_INPUT_VALUE_MASK  0x10u
+#define GET_NVM_READ_SI_INPUT_VALUE(__reg__)  (((__reg__) & 0x10) >> 4u)
+#define SET_NVM_READ_SI_INPUT_VALUE(__val__)  (((__val__) << 4u) & 0x10u)
+#define     NVM_READ_SO_INPUT_VALUE_SHIFT 5u
+#define     NVM_READ_SO_INPUT_VALUE_MASK  0x20u
+#define GET_NVM_READ_SO_INPUT_VALUE(__reg__)  (((__reg__) & 0x20) >> 5u)
+#define SET_NVM_READ_SO_INPUT_VALUE(__val__)  (((__val__) << 5u) & 0x20u)
+
 /** @brief Register definition for @ref NVM_t.Read. */
 typedef register_container RegNVMRead_t {
     /** @brief 32bit direct register access. */
     BCM5719_NVM_H_uint32_t r32;
+
+    BITFIELD_BEGIN(BCM5719_NVM_H_uint32_t, bits)
+#if defined(__LITTLE_ENDIAN__)
+        /** @brief Padding */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_1_0, 0, 2)
+        /** @brief When in bit-bang mode, this bit reads the current SCLK input value. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SCLKInputValue, 2, 1)
+        /** @brief When in bit-bang mode, this bit reads the current CSb input value. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, CSbInputValue, 3, 1)
+        /** @brief When in bit-bang mode, this bit reads the current SI input value. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SIInputValue, 4, 1)
+        /** @brief When in bit-bang mode, this bit reads the current SO input value. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SOInputValue, 5, 1)
+        /** @brief Padding */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_31_6, 6, 26)
+#elif defined(__BIG_ENDIAN__)
+        /** @brief Padding */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_31_6, 6, 26)
+        /** @brief When in bit-bang mode, this bit reads the current SO input value. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SOInputValue, 5, 1)
+        /** @brief When in bit-bang mode, this bit reads the current SI input value. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SIInputValue, 4, 1)
+        /** @brief When in bit-bang mode, this bit reads the current CSb input value. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, CSbInputValue, 3, 1)
+        /** @brief When in bit-bang mode, this bit reads the current SCLK input value. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SCLKInputValue, 2, 1)
+        /** @brief Padding */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_1_0, 0, 2)
+#else
+#error Unknown Endian
+#endif
+    BITFIELD_END(BCM5719_NVM_H_uint32_t, bits)
 #ifdef CXX_SIMULATOR
     /** @brief Register name for use with the simulator. */
     const char* getName(void) { return "Read"; }
@@ -273,6 +450,14 @@ typedef register_container RegNVMRead_t {
     {
         /** @brief constructor for @ref NVM_t.Read. */
         r32.setName("Read");
+        bits.SCLKInputValue.setBaseRegister(&r32);
+        bits.SCLKInputValue.setName("SCLKInputValue");
+        bits.CSbInputValue.setBaseRegister(&r32);
+        bits.CSbInputValue.setName("CSbInputValue");
+        bits.SIInputValue.setBaseRegister(&r32);
+        bits.SIInputValue.setName("SIInputValue");
+        bits.SOInputValue.setBaseRegister(&r32);
+        bits.SOInputValue.setName("SOInputValue");
     }
     RegNVMRead_t& operator=(const RegNVMRead_t& other)
     {
@@ -291,6 +476,18 @@ typedef register_container RegNVMRead_t {
 #define     NVM_NVM_CFG_1_BUFFER_MODE_MASK  0x2u
 #define GET_NVM_NVM_CFG_1_BUFFER_MODE(__reg__)  (((__reg__) & 0x2) >> 1u)
 #define SET_NVM_NVM_CFG_1_BUFFER_MODE(__val__)  (((__val__) << 1u) & 0x2u)
+#define     NVM_NVM_CFG_1_PASS_MODE_SHIFT 2u
+#define     NVM_NVM_CFG_1_PASS_MODE_MASK  0x4u
+#define GET_NVM_NVM_CFG_1_PASS_MODE(__reg__)  (((__reg__) & 0x4) >> 2u)
+#define SET_NVM_NVM_CFG_1_PASS_MODE(__val__)  (((__val__) << 2u) & 0x4u)
+#define     NVM_NVM_CFG_1_BITBANG_MODE_SHIFT 3u
+#define     NVM_NVM_CFG_1_BITBANG_MODE_MASK  0x8u
+#define GET_NVM_NVM_CFG_1_BITBANG_MODE(__reg__)  (((__reg__) & 0x8) >> 3u)
+#define SET_NVM_NVM_CFG_1_BITBANG_MODE(__val__)  (((__val__) << 3u) & 0x8u)
+#define     NVM_NVM_CFG_1_STATUS_BIT_SHIFT 4u
+#define     NVM_NVM_CFG_1_STATUS_BIT_MASK  0x70u
+#define GET_NVM_NVM_CFG_1_STATUS_BIT(__reg__)  (((__reg__) & 0x70) >> 4u)
+#define SET_NVM_NVM_CFG_1_STATUS_BIT(__val__)  (((__val__) << 4u) & 0x70u)
 #define     NVM_NVM_CFG_1_SPI_CLK_DIV_SHIFT 7u
 #define     NVM_NVM_CFG_1_SPI_CLK_DIV_MASK  0x780u
 #define GET_NVM_NVM_CFG_1_SPI_CLK_DIV(__reg__)  (((__reg__) & 0x780) >> 7u)
@@ -326,15 +523,19 @@ typedef register_container RegNVMNvmCfg1_t {
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, FlashMode, 0, 1)
         /** @brief Enable SSRAM Buffered Interface mode. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, BufferMode, 1, 1)
-        /** @brief Padding */
-        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_6_2, 2, 5)
+        /** @brief Enable pass-thorough mode to the byte level SPI and SEE state machines. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, PassMode, 2, 1)
+        /** @brief Enable bit-bang mode to control pins. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, BitbangMode, 3, 1)
+        /** @brief Bit Offset in status command response to interpret as the ready flag. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, StatusBit, 4, 3)
         /** @brief The equation to calculate the clock freq. for SCK is: CORE_CLK / ((SPI_CLK_DIV + 1) * 2) */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SPICLKDIV, 7, 4)
         /** @brief Padding */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_23_11, 11, 13)
         /** @brief  */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ProtectMode, 24, 1)
-        /** @brief  */
+        /** @brief Enables 1-Mbit devices as opposed to 512 Kbit. At CORE reset, this pin is set to the value of the SO pin. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, FlashSize, 25, 1)
         /** @brief Padding */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_27_26, 26, 2)
@@ -349,7 +550,7 @@ typedef register_container RegNVMNvmCfg1_t {
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, PageSize, 28, 3)
         /** @brief Padding */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_27_26, 26, 2)
-        /** @brief  */
+        /** @brief Enables 1-Mbit devices as opposed to 512 Kbit. At CORE reset, this pin is set to the value of the SO pin. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, FlashSize, 25, 1)
         /** @brief  */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ProtectMode, 24, 1)
@@ -357,8 +558,12 @@ typedef register_container RegNVMNvmCfg1_t {
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_23_11, 11, 13)
         /** @brief The equation to calculate the clock freq. for SCK is: CORE_CLK / ((SPI_CLK_DIV + 1) * 2) */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, SPICLKDIV, 7, 4)
-        /** @brief Padding */
-        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_6_2, 2, 5)
+        /** @brief Bit Offset in status command response to interpret as the ready flag. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, StatusBit, 4, 3)
+        /** @brief Enable bit-bang mode to control pins. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, BitbangMode, 3, 1)
+        /** @brief Enable pass-thorough mode to the byte level SPI and SEE state machines. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, PassMode, 2, 1)
         /** @brief Enable SSRAM Buffered Interface mode. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, BufferMode, 1, 1)
         /** @brief Enable Flash Interface mode. */
@@ -382,6 +587,12 @@ typedef register_container RegNVMNvmCfg1_t {
         bits.FlashMode.setName("FlashMode");
         bits.BufferMode.setBaseRegister(&r32);
         bits.BufferMode.setName("BufferMode");
+        bits.PassMode.setBaseRegister(&r32);
+        bits.PassMode.setName("PassMode");
+        bits.BitbangMode.setBaseRegister(&r32);
+        bits.BitbangMode.setName("BitbangMode");
+        bits.StatusBit.setBaseRegister(&r32);
+        bits.StatusBit.setName("StatusBit");
         bits.SPICLKDIV.setBaseRegister(&r32);
         bits.SPICLKDIV.setName("SPICLKDIV");
         bits.ProtectMode.setBaseRegister(&r32);

--- a/libs/NVRam/include/EM100.h
+++ b/libs/NVRam/include/EM100.h
@@ -1,10 +1,10 @@
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// @file       ape_purchar.c
+/// @file       EM100.h
 ///
 /// @project
 ///
-/// @brief      APE printf support Routines
+/// @brief      EM100 Debug Routines
 ///
 ////////////////////////////////////////////////////////////////////////////////
 ///
@@ -41,30 +41,17 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 /// @endcond
 ////////////////////////////////////////////////////////////////////////////////
+#ifndef EM100_H
+#define EM100_H
 
-#include <printf.h>
-#include <EM100.h>
-#include <APE_DEBUG.h>
-#include <APE_SHM.h>
+#include <types.h>
 
-void _putchar(char character)
-{
-    uint32_t write_pointer = DEBUG.WritePointer.r32;
-    uint32_t word_pointer = write_pointer / 4;
-    uint32_t byte_index = write_pointer % 4;
-    uint32_t byte_mask = 0xFF << (byte_index * 8);
+/**
+ * Print a character out the SPI bus using the EM100 hyperterminal protocl
+ *
+ * This routine caches all characters untill a newline is found or the
+ * buffer is full.
+ */
+void NVRam_EM100_putchar(char c);
 
-    uint32_t new_word = DEBUG.Buffer[word_pointer].r32 & ~byte_mask;
-    new_word |= character << (byte_index * 8);
-    DEBUG.Buffer[word_pointer].r32 = new_word;
-    write_pointer++;
-
-    if(write_pointer >= sizeof(DEBUG.Buffer))
-    {
-        write_pointer = 0;
-    }
-
-    DEBUG.WritePointer.r32 = write_pointer;
-
-    NVRam_EM100_putchar(character);
-}
+#endif /* EM100_H */

--- a/libs/NVRam/include/NVRam.h
+++ b/libs/NVRam/include/NVRam.h
@@ -48,6 +48,7 @@
 
 bool NVRam_acquireLock(void);
 bool NVRam_releaseLock(void);
+bool NVRam_releaseAllLocks(void);
 
 uint32_t NVRam_readWord(uint32_t address);
 void NVRam_read(uint32_t address, uint32_t *buffer, uint32_t words);

--- a/libs/NVRam/nvm.c
+++ b/libs/NVRam/nvm.c
@@ -55,10 +55,16 @@
 
 #ifdef CXX_SIMULATOR
 #include <arpa/inet.h>
-#define REQ ReqSet2
-#define CLR ReqClr2
-#define WON ArbWon2
-#else /* Firmware */
+#define REQ ReqSet1
+#define CLR ReqClr1
+#define WON ArbWon1
+#elif __arm__                /* APE */
+#define ntohl(__x__) (__x__) /* Todo: swap */
+#define htonl(__x__) (__x__) /* Todo: swap */
+#define REQ ReqSet0
+#define CLR ReqClr0
+#define WON ArbWon0
+#else /* RX CPU Firmware */
 #define ntohl(__x__) (__x__)
 #define htonl(__x__) (__x__)
 #define REQ ReqSet0
@@ -137,6 +143,19 @@ bool NVRam_releaseLock(void)
     RegNVMSoftwareArbitration_t req;
     req.r32 = 0;
     req.bits.CLR = 1;
+    NVM.SoftwareArbitration = req;
+
+    return true;
+}
+
+bool NVRam_releaseAllLocks(void)
+{
+    RegNVMSoftwareArbitration_t req;
+    req.r32 = 0;
+    req.bits.ReqClr0 = 1;
+    req.bits.ReqClr1 = 1;
+    req.bits.ReqClr2 = 1;
+    req.bits.ReqClr3 = 1;
     NVM.SoftwareArbitration = req;
 
     return true;

--- a/libs/printf/CMakeLists.txt
+++ b/libs/printf/CMakeLists.txt
@@ -60,7 +60,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC .)
 
 # ARM Library
 arm_add_library(${PROJECT_NAME}-arm STATIC ${SOURCES} ape_putchar.c)
-target_link_libraries(${PROJECT_NAME}-arm PRIVATE Network-arm MII-arm APE-arm)
+target_link_libraries(${PROJECT_NAME}-arm PRIVATE Network-arm MII-arm APE-arm NVRam-arm)
 target_include_directories(${PROJECT_NAME}-arm PUBLIC ../../include)
 target_include_directories(${PROJECT_NAME}-arm PUBLIC .)
 


### PR DESCRIPTION
- Enable bitbanging with the NVM block
- On printf for the APE, send strings out both the SPI bus as well as to the apeconsole memory.