### PR TITLE
ipxact: Update ipxact to enable enum printouts on the simulator.

### DIFF
--- a/include/APE_APE.h
+++ b/include/APE_APE.h
@@ -420,12 +420,42 @@ typedef register_container RegAPEStatus_t {
         bits.LAN0Dstate.setName("LAN0Dstate");
         bits.BootMode.setBaseRegister(&r32);
         bits.BootMode.setName("BootMode");
+        bits.BootMode.addEnum("NVRAM", 0x0);
+        bits.BootMode.addEnum("Fast", 0x1);
+
         bits.LAN1Dstate.setBaseRegister(&r32);
         bits.LAN1Dstate.setName("LAN1Dstate");
         bits.BootStatusB.setBaseRegister(&r32);
         bits.BootStatusB.setName("BootStatusB");
+        bits.BootStatusB.addEnum("Prog 0", 0x0);
+        bits.BootStatusB.addEnum("Prog 1", 0x1);
+        bits.BootStatusB.addEnum("BPC Enter", 0x2);
+        bits.BootStatusB.addEnum("Decode", 0x3);
+        bits.BootStatusB.addEnum("Read NVRAM Header", 0x4);
+        bits.BootStatusB.addEnum("Read Code", 0x5);
+        bits.BootStatusB.addEnum("Jump", 0x6);
+        bits.BootStatusB.addEnum("Prog 7", 0x7);
+        bits.BootStatusB.addEnum("BPC Success", 0x8);
+
         bits.BootStatusA.setBaseRegister(&r32);
         bits.BootStatusA.setName("BootStatusA");
+        bits.BootStatusA.addEnum("None", 0x0);
+        bits.BootStatusA.addEnum("NMI Exception", 0x1);
+        bits.BootStatusA.addEnum("Fault Exception", 0x2);
+        bits.BootStatusA.addEnum("Memory Check", 0x3);
+        bits.BootStatusA.addEnum("Unknown 4", 0x4);
+        bits.BootStatusA.addEnum("Romloader Disabled", 0x5);
+        bits.BootStatusA.addEnum("Magic Number", 0x6);
+        bits.BootStatusA.addEnum("APE Init Code", 0x7);
+        bits.BootStatusA.addEnum("Header Checksum", 0x8);
+        bits.BootStatusA.addEnum("APE Header", 0x9);
+        bits.BootStatusA.addEnum("Image Checksum", 0xa);
+        bits.BootStatusA.addEnum("NVRAM Checksum", 0xb);
+        bits.BootStatusA.addEnum("Invalid Type", 0xc);
+        bits.BootStatusA.addEnum("ROM Loader Checksum", 0xd);
+        bits.BootStatusA.addEnum("Invalid Unzip Len", 0xe);
+        bits.BootStatusA.addEnum("Unknown F", 0xf);
+
     }
     RegAPEStatus_t& operator=(const RegAPEStatus_t& other)
     {
@@ -1043,6 +1073,11 @@ typedef register_container RegAPERxPoolRetire_t {
         bits.Retire.setName("Retire");
         bits.State.setBaseRegister(&r32);
         bits.State.setName("State");
+        bits.State.addEnum("Processing", 0x0);
+        bits.State.addEnum("Retired OK", 0x1);
+        bits.State.addEnum("Error: Full", 0x2);
+        bits.State.addEnum("Error: In Halt", 0x3);
+
         bits.Count.setBaseRegister(&r32);
         bits.Count.setName("Count");
     }
@@ -1233,10 +1268,17 @@ typedef register_container RegAPETxToNetBufferAllocator_t {
         r32.setName("TxToNetBufferAllocator0");
         bits.Index.setBaseRegister(&r32);
         bits.Index.setName("Index");
+        bits.Index.addEnum("Block Size", 0x80);
+
         bits.RequestAllocation.setBaseRegister(&r32);
         bits.RequestAllocation.setName("RequestAllocation");
         bits.State.setBaseRegister(&r32);
         bits.State.setName("State");
+        bits.State.addEnum("Processing", 0x0);
+        bits.State.addEnum("Allocation OK", 0x1);
+        bits.State.addEnum("Error: Empty", 0x2);
+        bits.State.addEnum("Error: In Halt", 0x3);
+
     }
     RegAPETxToNetBufferAllocator_t& operator=(const RegAPETxToNetBufferAllocator_t& other)
     {
@@ -1822,6 +1864,16 @@ typedef register_container RegAPECpuStatus_t {
         r32.setName("CpuStatus");
         bits.Status.setBaseRegister(&r32);
         bits.Status.setName("Status");
+        bits.Status.addEnum("Running", 0x0);
+        bits.Status.addEnum("Halted", 0x1);
+        bits.Status.addEnum("Locked Out", 0x2);
+        bits.Status.addEnum("Sleeping", 0x3);
+        bits.Status.addEnum("Deep Sleep", 0x4);
+        bits.Status.addEnum("Interrupt Pending", 0x8);
+        bits.Status.addEnum("Interrupt Entry", 0x9);
+        bits.Status.addEnum("Interrupt Exit", 0xa);
+        bits.Status.addEnum("Interrupt Return", 0xb);
+
         bits.ActiveInterrupt.setBaseRegister(&r32);
         bits.ActiveInterrupt.setName("ActiveInterrupt");
     }

--- a/include/APE_DEVICE.h
+++ b/include/APE_DEVICE.h
@@ -302,10 +302,20 @@ typedef register_container RegDEVICEMiscellaneousHostControl_t {
         bits.EnableTLPMinorErrorTolerance.setName("EnableTLPMinorErrorTolerance");
         bits.MetalRevID.setBaseRegister(&r32);
         bits.MetalRevID.setName("MetalRevID");
+        bits.MetalRevID.addEnum("0", 0x0);
+        bits.MetalRevID.addEnum("1", 0x1);
+        bits.MetalRevID.addEnum("2", 0x2);
+
         bits.AllLayerID.setBaseRegister(&r32);
         bits.AllLayerID.setName("AllLayerID");
+        bits.AllLayerID.addEnum("A", 0x0);
+        bits.AllLayerID.addEnum("B", 0x1);
+        bits.AllLayerID.addEnum("C", 0x2);
+
         bits.ProductID.setBaseRegister(&r32);
         bits.ProductID.setName("ProductID");
+        bits.ProductID.addEnum("New Product Mapping", 0xf);
+
     }
     RegDEVICEMiscellaneousHostControl_t& operator=(const RegDEVICEMiscellaneousHostControl_t& other)
     {
@@ -640,6 +650,9 @@ typedef register_container RegDEVICELinkStatusControl_t {
         r32.setName("LinkStatusControl");
         bits.NegotiatedLinkSpeed.setBaseRegister(&r32);
         bits.NegotiatedLinkSpeed.setName("NegotiatedLinkSpeed");
+        bits.NegotiatedLinkSpeed.addEnum("PCIe 1.0", 0x1);
+        bits.NegotiatedLinkSpeed.addEnum("PCIe 2.0", 0x2);
+
         bits.NegotiatedLinkWidth.setBaseRegister(&r32);
         bits.NegotiatedLinkWidth.setName("NegotiatedLinkWidth");
     }
@@ -953,6 +966,11 @@ typedef register_container RegDEVICEEmacMode_t {
         bits.HalfDuplex.setName("HalfDuplex");
         bits.PortMode.setBaseRegister(&r32);
         bits.PortMode.setName("PortMode");
+        bits.PortMode.addEnum("None", 0x0);
+        bits.PortMode.addEnum("10/100", 0x1);
+        bits.PortMode.addEnum("1000", 0x2);
+        bits.PortMode.addEnum("TBI", 0x3);
+
         bits.LoopbackMode.setBaseRegister(&r32);
         bits.LoopbackMode.setName("LoopbackMode");
         bits.TaggedMACControl.setBaseRegister(&r32);
@@ -1368,7 +1386,7 @@ typedef register_container RegDEVICEEmacEvent_t {
 #define     DEVICE_LED_CONTROL_LED_MODE_MAC 0x0u
 #define     DEVICE_LED_CONTROL_LED_MODE_PHY_MODE_1 0x1u
 #define     DEVICE_LED_CONTROL_LED_MODE_PHY_MODE_2 0x2u
-#define     DEVICE_LED_CONTROL_LED_MODE_PHY_MODE_1_ 0x3u
+#define     DEVICE_LED_CONTROL_LED_MODE_PHY_MODE_3 0x3u
 
 #define     DEVICE_LED_CONTROL_MAC_MODE_SHIFT 13u
 #define     DEVICE_LED_CONTROL_MAC_MODE_MASK  0x2000u
@@ -1502,6 +1520,11 @@ typedef register_container RegDEVICELedControl_t {
         bits.LEDStatusTraffic.setName("LEDStatusTraffic");
         bits.LEDMode.setBaseRegister(&r32);
         bits.LEDMode.setName("LEDMode");
+        bits.LEDMode.addEnum("MAC", 0x0);
+        bits.LEDMode.addEnum("PHY Mode 1", 0x1);
+        bits.LEDMode.addEnum("PHY Mode 2", 0x2);
+        bits.LEDMode.addEnum("PHY Mode 3", 0x3);
+
         bits.MACMode.setBaseRegister(&r32);
         bits.MACMode.setName("MACMode");
         bits.SharedTraffic_DIV_LinkLEDMode.setBaseRegister(&r32);
@@ -1912,8 +1935,20 @@ typedef register_container RegDEVICEMiiCommunication_t {
         bits.RegisterAddress.setName("RegisterAddress");
         bits.PHYAddress.setBaseRegister(&r32);
         bits.PHYAddress.setName("PHYAddress");
+        bits.PHYAddress.addEnum("PHY 0", 0x1);
+        bits.PHYAddress.addEnum("PHY 1", 0x2);
+        bits.PHYAddress.addEnum("PHY 2", 0x3);
+        bits.PHYAddress.addEnum("PHY 3", 0x4);
+        bits.PHYAddress.addEnum("SGMII 0", 0x8);
+        bits.PHYAddress.addEnum("SGMII 1", 0x9);
+        bits.PHYAddress.addEnum("SGMII 2", 0xa);
+        bits.PHYAddress.addEnum("SGMII 3", 0xb);
+
         bits.Command.setBaseRegister(&r32);
         bits.Command.setName("Command");
+        bits.Command.addEnum("Write", 0x1);
+        bits.Command.addEnum("Read", 0x2);
+
         bits.ReadFailed.setBaseRegister(&r32);
         bits.ReadFailed.setName("ReadFailed");
         bits.Start_DIV_Busy.setBaseRegister(&r32);
@@ -2901,6 +2936,9 @@ typedef register_container RegDEVICESgmiiStatus_t {
         bits.PauseTX.setName("PauseTX");
         bits.MediaSelectionMode.setBaseRegister(&r32);
         bits.MediaSelectionMode.setName("MediaSelectionMode");
+        bits.MediaSelectionMode.addEnum("Copper", 0x0);
+        bits.MediaSelectionMode.addEnum("SGMII", 0x1);
+
         bits.PCSCRSDetect.setBaseRegister(&r32);
         bits.PCSCRSDetect.setName("PCSCRSDetect");
         bits.ExternalCRSDetect.setBaseRegister(&r32);
@@ -3153,6 +3191,18 @@ typedef register_container RegDEVICELinkAwarePowerModeClockPolicy_t {
         r32.setName("LinkAwarePowerModeClockPolicy");
         bits.MACClockSwitch.setBaseRegister(&r32);
         bits.MACClockSwitch.setName("MACClockSwitch");
+        bits.MACClockSwitch.addEnum("60.0MHz", 0x1);
+        bits.MACClockSwitch.addEnum("30.0MHz", 0x3);
+        bits.MACClockSwitch.addEnum("15.0MHz", 0x5);
+        bits.MACClockSwitch.addEnum("7.5MHz", 0x7);
+        bits.MACClockSwitch.addEnum("3.75MHz", 0x9);
+        bits.MACClockSwitch.addEnum("12.5MHz", 0x11);
+        bits.MACClockSwitch.addEnum("6.25MHz", 0x13);
+        bits.MACClockSwitch.addEnum("3.125MHz", 0x15);
+        bits.MACClockSwitch.addEnum("1.563MHz", 0x17);
+        bits.MACClockSwitch.addEnum("781kHz", 0x19);
+        bits.MACClockSwitch.addEnum("12.5MHz/1.25MHz", 0x1f);
+
     }
     RegDEVICELinkAwarePowerModeClockPolicy_t& operator=(const RegDEVICELinkAwarePowerModeClockPolicy_t& other)
     {
@@ -3412,12 +3462,21 @@ typedef register_container RegDEVICEStatus_t {
         bits.LinkIdleStatus.setName("LinkIdleStatus");
         bits.EthernetLinkStatus.setBaseRegister(&r32);
         bits.EthernetLinkStatus.setName("EthernetLinkStatus");
+        bits.EthernetLinkStatus.addEnum("1000 Mb", 0x0);
+        bits.EthernetLinkStatus.addEnum("100 Mb", 0x1);
+        bits.EthernetLinkStatus.addEnum("10 Mb", 0x2);
+        bits.EthernetLinkStatus.addEnum("No Link", 0x3);
+
         bits.WOLMagicPacketDetectionEnablePort1.setBaseRegister(&r32);
         bits.WOLMagicPacketDetectionEnablePort1.setName("WOLMagicPacketDetectionEnablePort1");
         bits.WOLACPIDetectionEnablePort1.setBaseRegister(&r32);
         bits.WOLACPIDetectionEnablePort1.setName("WOLACPIDetectionEnablePort1");
         bits.APEStatus.setBaseRegister(&r32);
         bits.APEStatus.setName("APEStatus");
+        bits.APEStatus.addEnum("Active", 0x0);
+        bits.APEStatus.addEnum("Sleep", 0x1);
+        bits.APEStatus.addEnum("Deep Sleep", 0x2);
+
         bits.FunctionEnable.setBaseRegister(&r32);
         bits.FunctionEnable.setName("FunctionEnable");
         bits.FunctionNumber.setBaseRegister(&r32);
@@ -4314,8 +4373,18 @@ typedef register_container RegDEVICELsoNonlsoBdReadDmaCorruptionEnableControl_t 
         r32.setName("LsoNonlsoBdReadDmaCorruptionEnableControl");
         bits.PCIRequestBurstLengthforBDRDMAEngine.setBaseRegister(&r32);
         bits.PCIRequestBurstLengthforBDRDMAEngine.setName("PCIRequestBurstLengthforBDRDMAEngine");
+        bits.PCIRequestBurstLengthforBDRDMAEngine.addEnum("128B", 0x0);
+        bits.PCIRequestBurstLengthforBDRDMAEngine.addEnum("256B", 0x1);
+        bits.PCIRequestBurstLengthforBDRDMAEngine.addEnum("512B", 0x2);
+        bits.PCIRequestBurstLengthforBDRDMAEngine.addEnum("4K", 0x3);
+
         bits.PCIRequestBurstLengthforNonLSORDMAEngine.setBaseRegister(&r32);
         bits.PCIRequestBurstLengthforNonLSORDMAEngine.setName("PCIRequestBurstLengthforNonLSORDMAEngine");
+        bits.PCIRequestBurstLengthforNonLSORDMAEngine.addEnum("128B", 0x0);
+        bits.PCIRequestBurstLengthforNonLSORDMAEngine.addEnum("256B", 0x1);
+        bits.PCIRequestBurstLengthforNonLSORDMAEngine.addEnum("512B", 0x2);
+        bits.PCIRequestBurstLengthforNonLSORDMAEngine.addEnum("4K", 0x3);
+
     }
     RegDEVICELsoNonlsoBdReadDmaCorruptionEnableControl_t& operator=(const RegDEVICELsoNonlsoBdReadDmaCorruptionEnableControl_t& other)
     {
@@ -6086,14 +6155,35 @@ typedef register_container RegDEVICEPciPowerBudget0_t {
         bits.BasePower.setName("BasePower");
         bits.DataScale.setBaseRegister(&r32);
         bits.DataScale.setName("DataScale");
+        bits.DataScale.addEnum("1.0x", 0x0);
+        bits.DataScale.addEnum("0.1x", 0x1);
+        bits.DataScale.addEnum("0.01x", 0x2);
+        bits.DataScale.addEnum("0.001x", 0x3);
+
         bits.PMSubState.setBaseRegister(&r32);
         bits.PMSubState.setName("PMSubState");
         bits.PMState.setBaseRegister(&r32);
         bits.PMState.setName("PMState");
+        bits.PMState.addEnum("D0", 0x0);
+        bits.PMState.addEnum("D1", 0x1);
+        bits.PMState.addEnum("D2", 0x2);
+        bits.PMState.addEnum("D3", 0x3);
+
         bits.Type.setBaseRegister(&r32);
         bits.Type.setName("Type");
+        bits.Type.addEnum("PME Aux", 0x0);
+        bits.Type.addEnum("Auxiliary", 0x1);
+        bits.Type.addEnum("Idle", 0x2);
+        bits.Type.addEnum("Sustained", 0x3);
+        bits.Type.addEnum("Maximum", 0x7);
+
         bits.PowerRail.setBaseRegister(&r32);
         bits.PowerRail.setName("PowerRail");
+        bits.PowerRail.addEnum("Power 12V", 0x0);
+        bits.PowerRail.addEnum("Power 3.3V", 0x1);
+        bits.PowerRail.addEnum("Power 1.5V or 1.8V", 0x2);
+        bits.PowerRail.addEnum("Thermal", 0x7);
+
     }
     RegDEVICEPciPowerBudget0_t& operator=(const RegDEVICEPciPowerBudget0_t& other)
     {
@@ -6205,14 +6295,35 @@ typedef register_container RegDEVICEPciPowerBudget1_t {
         bits.BasePower.setName("BasePower");
         bits.DataScale.setBaseRegister(&r32);
         bits.DataScale.setName("DataScale");
+        bits.DataScale.addEnum("1.0x", 0x0);
+        bits.DataScale.addEnum("0.1x", 0x1);
+        bits.DataScale.addEnum("0.01x", 0x2);
+        bits.DataScale.addEnum("0.001x", 0x3);
+
         bits.PMSubState.setBaseRegister(&r32);
         bits.PMSubState.setName("PMSubState");
         bits.PMState.setBaseRegister(&r32);
         bits.PMState.setName("PMState");
+        bits.PMState.addEnum("D0", 0x0);
+        bits.PMState.addEnum("D1", 0x1);
+        bits.PMState.addEnum("D2", 0x2);
+        bits.PMState.addEnum("D3", 0x3);
+
         bits.Type.setBaseRegister(&r32);
         bits.Type.setName("Type");
+        bits.Type.addEnum("PME Aux", 0x0);
+        bits.Type.addEnum("Auxiliary", 0x1);
+        bits.Type.addEnum("Idle", 0x2);
+        bits.Type.addEnum("Sustained", 0x3);
+        bits.Type.addEnum("Maximum", 0x7);
+
         bits.PowerRail.setBaseRegister(&r32);
         bits.PowerRail.setName("PowerRail");
+        bits.PowerRail.addEnum("Power 12V", 0x0);
+        bits.PowerRail.addEnum("Power 3.3V", 0x1);
+        bits.PowerRail.addEnum("Power 1.5V or 1.8V", 0x2);
+        bits.PowerRail.addEnum("Thermal", 0x7);
+
     }
     RegDEVICEPciPowerBudget1_t& operator=(const RegDEVICEPciPowerBudget1_t& other)
     {
@@ -6324,14 +6435,35 @@ typedef register_container RegDEVICEPciPowerBudget2_t {
         bits.BasePower.setName("BasePower");
         bits.DataScale.setBaseRegister(&r32);
         bits.DataScale.setName("DataScale");
+        bits.DataScale.addEnum("1.0x", 0x0);
+        bits.DataScale.addEnum("0.1x", 0x1);
+        bits.DataScale.addEnum("0.01x", 0x2);
+        bits.DataScale.addEnum("0.001x", 0x3);
+
         bits.PMSubState.setBaseRegister(&r32);
         bits.PMSubState.setName("PMSubState");
         bits.PMState.setBaseRegister(&r32);
         bits.PMState.setName("PMState");
+        bits.PMState.addEnum("D0", 0x0);
+        bits.PMState.addEnum("D1", 0x1);
+        bits.PMState.addEnum("D2", 0x2);
+        bits.PMState.addEnum("D3", 0x3);
+
         bits.Type.setBaseRegister(&r32);
         bits.Type.setName("Type");
+        bits.Type.addEnum("PME Aux", 0x0);
+        bits.Type.addEnum("Auxiliary", 0x1);
+        bits.Type.addEnum("Idle", 0x2);
+        bits.Type.addEnum("Sustained", 0x3);
+        bits.Type.addEnum("Maximum", 0x7);
+
         bits.PowerRail.setBaseRegister(&r32);
         bits.PowerRail.setName("PowerRail");
+        bits.PowerRail.addEnum("Power 12V", 0x0);
+        bits.PowerRail.addEnum("Power 3.3V", 0x1);
+        bits.PowerRail.addEnum("Power 1.5V or 1.8V", 0x2);
+        bits.PowerRail.addEnum("Thermal", 0x7);
+
     }
     RegDEVICEPciPowerBudget2_t& operator=(const RegDEVICEPciPowerBudget2_t& other)
     {
@@ -6443,14 +6575,35 @@ typedef register_container RegDEVICEPciPowerBudget3_t {
         bits.BasePower.setName("BasePower");
         bits.DataScale.setBaseRegister(&r32);
         bits.DataScale.setName("DataScale");
+        bits.DataScale.addEnum("1.0x", 0x0);
+        bits.DataScale.addEnum("0.1x", 0x1);
+        bits.DataScale.addEnum("0.01x", 0x2);
+        bits.DataScale.addEnum("0.001x", 0x3);
+
         bits.PMSubState.setBaseRegister(&r32);
         bits.PMSubState.setName("PMSubState");
         bits.PMState.setBaseRegister(&r32);
         bits.PMState.setName("PMState");
+        bits.PMState.addEnum("D0", 0x0);
+        bits.PMState.addEnum("D1", 0x1);
+        bits.PMState.addEnum("D2", 0x2);
+        bits.PMState.addEnum("D3", 0x3);
+
         bits.Type.setBaseRegister(&r32);
         bits.Type.setName("Type");
+        bits.Type.addEnum("PME Aux", 0x0);
+        bits.Type.addEnum("Auxiliary", 0x1);
+        bits.Type.addEnum("Idle", 0x2);
+        bits.Type.addEnum("Sustained", 0x3);
+        bits.Type.addEnum("Maximum", 0x7);
+
         bits.PowerRail.setBaseRegister(&r32);
         bits.PowerRail.setName("PowerRail");
+        bits.PowerRail.addEnum("Power 12V", 0x0);
+        bits.PowerRail.addEnum("Power 3.3V", 0x1);
+        bits.PowerRail.addEnum("Power 1.5V or 1.8V", 0x2);
+        bits.PowerRail.addEnum("Thermal", 0x7);
+
     }
     RegDEVICEPciPowerBudget3_t& operator=(const RegDEVICEPciPowerBudget3_t& other)
     {
@@ -6562,14 +6715,35 @@ typedef register_container RegDEVICEPciPowerBudget4_t {
         bits.BasePower.setName("BasePower");
         bits.DataScale.setBaseRegister(&r32);
         bits.DataScale.setName("DataScale");
+        bits.DataScale.addEnum("1.0x", 0x0);
+        bits.DataScale.addEnum("0.1x", 0x1);
+        bits.DataScale.addEnum("0.01x", 0x2);
+        bits.DataScale.addEnum("0.001x", 0x3);
+
         bits.PMSubState.setBaseRegister(&r32);
         bits.PMSubState.setName("PMSubState");
         bits.PMState.setBaseRegister(&r32);
         bits.PMState.setName("PMState");
+        bits.PMState.addEnum("D0", 0x0);
+        bits.PMState.addEnum("D1", 0x1);
+        bits.PMState.addEnum("D2", 0x2);
+        bits.PMState.addEnum("D3", 0x3);
+
         bits.Type.setBaseRegister(&r32);
         bits.Type.setName("Type");
+        bits.Type.addEnum("PME Aux", 0x0);
+        bits.Type.addEnum("Auxiliary", 0x1);
+        bits.Type.addEnum("Idle", 0x2);
+        bits.Type.addEnum("Sustained", 0x3);
+        bits.Type.addEnum("Maximum", 0x7);
+
         bits.PowerRail.setBaseRegister(&r32);
         bits.PowerRail.setName("PowerRail");
+        bits.PowerRail.addEnum("Power 12V", 0x0);
+        bits.PowerRail.addEnum("Power 3.3V", 0x1);
+        bits.PowerRail.addEnum("Power 1.5V or 1.8V", 0x2);
+        bits.PowerRail.addEnum("Thermal", 0x7);
+
     }
     RegDEVICEPciPowerBudget4_t& operator=(const RegDEVICEPciPowerBudget4_t& other)
     {
@@ -6681,14 +6855,35 @@ typedef register_container RegDEVICEPciPowerBudget5_t {
         bits.BasePower.setName("BasePower");
         bits.DataScale.setBaseRegister(&r32);
         bits.DataScale.setName("DataScale");
+        bits.DataScale.addEnum("1.0x", 0x0);
+        bits.DataScale.addEnum("0.1x", 0x1);
+        bits.DataScale.addEnum("0.01x", 0x2);
+        bits.DataScale.addEnum("0.001x", 0x3);
+
         bits.PMSubState.setBaseRegister(&r32);
         bits.PMSubState.setName("PMSubState");
         bits.PMState.setBaseRegister(&r32);
         bits.PMState.setName("PMState");
+        bits.PMState.addEnum("D0", 0x0);
+        bits.PMState.addEnum("D1", 0x1);
+        bits.PMState.addEnum("D2", 0x2);
+        bits.PMState.addEnum("D3", 0x3);
+
         bits.Type.setBaseRegister(&r32);
         bits.Type.setName("Type");
+        bits.Type.addEnum("PME Aux", 0x0);
+        bits.Type.addEnum("Auxiliary", 0x1);
+        bits.Type.addEnum("Idle", 0x2);
+        bits.Type.addEnum("Sustained", 0x3);
+        bits.Type.addEnum("Maximum", 0x7);
+
         bits.PowerRail.setBaseRegister(&r32);
         bits.PowerRail.setName("PowerRail");
+        bits.PowerRail.addEnum("Power 12V", 0x0);
+        bits.PowerRail.addEnum("Power 3.3V", 0x1);
+        bits.PowerRail.addEnum("Power 1.5V or 1.8V", 0x2);
+        bits.PowerRail.addEnum("Thermal", 0x7);
+
     }
     RegDEVICEPciPowerBudget5_t& operator=(const RegDEVICEPciPowerBudget5_t& other)
     {
@@ -6800,14 +6995,35 @@ typedef register_container RegDEVICEPciPowerBudget6_t {
         bits.BasePower.setName("BasePower");
         bits.DataScale.setBaseRegister(&r32);
         bits.DataScale.setName("DataScale");
+        bits.DataScale.addEnum("1.0x", 0x0);
+        bits.DataScale.addEnum("0.1x", 0x1);
+        bits.DataScale.addEnum("0.01x", 0x2);
+        bits.DataScale.addEnum("0.001x", 0x3);
+
         bits.PMSubState.setBaseRegister(&r32);
         bits.PMSubState.setName("PMSubState");
         bits.PMState.setBaseRegister(&r32);
         bits.PMState.setName("PMState");
+        bits.PMState.addEnum("D0", 0x0);
+        bits.PMState.addEnum("D1", 0x1);
+        bits.PMState.addEnum("D2", 0x2);
+        bits.PMState.addEnum("D3", 0x3);
+
         bits.Type.setBaseRegister(&r32);
         bits.Type.setName("Type");
+        bits.Type.addEnum("PME Aux", 0x0);
+        bits.Type.addEnum("Auxiliary", 0x1);
+        bits.Type.addEnum("Idle", 0x2);
+        bits.Type.addEnum("Sustained", 0x3);
+        bits.Type.addEnum("Maximum", 0x7);
+
         bits.PowerRail.setBaseRegister(&r32);
         bits.PowerRail.setName("PowerRail");
+        bits.PowerRail.addEnum("Power 12V", 0x0);
+        bits.PowerRail.addEnum("Power 3.3V", 0x1);
+        bits.PowerRail.addEnum("Power 1.5V or 1.8V", 0x2);
+        bits.PowerRail.addEnum("Thermal", 0x7);
+
     }
     RegDEVICEPciPowerBudget6_t& operator=(const RegDEVICEPciPowerBudget6_t& other)
     {
@@ -6919,14 +7135,35 @@ typedef register_container RegDEVICEPciPowerBudget7_t {
         bits.BasePower.setName("BasePower");
         bits.DataScale.setBaseRegister(&r32);
         bits.DataScale.setName("DataScale");
+        bits.DataScale.addEnum("1.0x", 0x0);
+        bits.DataScale.addEnum("0.1x", 0x1);
+        bits.DataScale.addEnum("0.01x", 0x2);
+        bits.DataScale.addEnum("0.001x", 0x3);
+
         bits.PMSubState.setBaseRegister(&r32);
         bits.PMSubState.setName("PMSubState");
         bits.PMState.setBaseRegister(&r32);
         bits.PMState.setName("PMState");
+        bits.PMState.addEnum("D0", 0x0);
+        bits.PMState.addEnum("D1", 0x1);
+        bits.PMState.addEnum("D2", 0x2);
+        bits.PMState.addEnum("D3", 0x3);
+
         bits.Type.setBaseRegister(&r32);
         bits.Type.setName("Type");
+        bits.Type.addEnum("PME Aux", 0x0);
+        bits.Type.addEnum("Auxiliary", 0x1);
+        bits.Type.addEnum("Idle", 0x2);
+        bits.Type.addEnum("Sustained", 0x3);
+        bits.Type.addEnum("Maximum", 0x7);
+
         bits.PowerRail.setBaseRegister(&r32);
         bits.PowerRail.setName("PowerRail");
+        bits.PowerRail.addEnum("Power 12V", 0x0);
+        bits.PowerRail.addEnum("Power 3.3V", 0x1);
+        bits.PowerRail.addEnum("Power 1.5V or 1.8V", 0x2);
+        bits.PowerRail.addEnum("Thermal", 0x7);
+
     }
     RegDEVICEPciPowerBudget7_t& operator=(const RegDEVICEPciPowerBudget7_t& other)
     {
@@ -7736,14 +7973,43 @@ typedef register_container RegDEVICEEavRefClockControl_t {
         r32.setName("EavRefClockControl");
         bits.TimesyncGPIOMapping.setBaseRegister(&r32);
         bits.TimesyncGPIOMapping.setName("TimesyncGPIOMapping");
+        bits.TimesyncGPIOMapping.addEnum("Snap-Shot[0]", 0x0);
+        bits.TimesyncGPIOMapping.addEnum("Snap-Shot[1]", 0x1);
+        bits.TimesyncGPIOMapping.addEnum("Time Watchdog[0]", 0x2);
+        bits.TimesyncGPIOMapping.addEnum("Time Watchdog[1]", 0x3);
+
         bits.APEGPIO0Mapping.setBaseRegister(&r32);
         bits.APEGPIO0Mapping.setName("APEGPIO0Mapping");
+        bits.APEGPIO0Mapping.addEnum("Not Used", 0x0);
+        bits.APEGPIO0Mapping.addEnum("Snap-Shot[0]", 0x4);
+        bits.APEGPIO0Mapping.addEnum("Snap-Shot[1]", 0x5);
+        bits.APEGPIO0Mapping.addEnum("Time Watchdog[0]", 0x6);
+        bits.APEGPIO0Mapping.addEnum("Time Watchdog[1]", 0x7);
+
         bits.APEGPIO1Mapping.setBaseRegister(&r32);
         bits.APEGPIO1Mapping.setName("APEGPIO1Mapping");
+        bits.APEGPIO1Mapping.addEnum("Not Used", 0x0);
+        bits.APEGPIO1Mapping.addEnum("Snap-Shot[0]", 0x4);
+        bits.APEGPIO1Mapping.addEnum("Snap-Shot[1]", 0x5);
+        bits.APEGPIO1Mapping.addEnum("Time Watchdog[0]", 0x6);
+        bits.APEGPIO1Mapping.addEnum("Time Watchdog[1]", 0x7);
+
         bits.APEGPIO2Mapping.setBaseRegister(&r32);
         bits.APEGPIO2Mapping.setName("APEGPIO2Mapping");
+        bits.APEGPIO2Mapping.addEnum("Not Used", 0x0);
+        bits.APEGPIO2Mapping.addEnum("Snap-Shot[0]", 0x4);
+        bits.APEGPIO2Mapping.addEnum("Snap-Shot[1]", 0x5);
+        bits.APEGPIO2Mapping.addEnum("Time Watchdog[0]", 0x6);
+        bits.APEGPIO2Mapping.addEnum("Time Watchdog[1]", 0x7);
+
         bits.APEGPIO3Mapping.setBaseRegister(&r32);
         bits.APEGPIO3Mapping.setName("APEGPIO3Mapping");
+        bits.APEGPIO3Mapping.addEnum("Not Used", 0x0);
+        bits.APEGPIO3Mapping.addEnum("Snap-Shot[0]", 0x4);
+        bits.APEGPIO3Mapping.addEnum("Snap-Shot[1]", 0x5);
+        bits.APEGPIO3Mapping.addEnum("Time Watchdog[0]", 0x6);
+        bits.APEGPIO3Mapping.addEnum("Time Watchdog[1]", 0x7);
+
     }
     RegDEVICEEavRefClockControl_t& operator=(const RegDEVICEEavRefClockControl_t& other)
     {

--- a/include/APE_FILTERS0.h
+++ b/include/APE_FILTERS0.h
@@ -226,8 +226,22 @@ typedef register_container RegFILTERSElementConfig_t {
         bits.RuleClass.setName("RuleClass");
         bits.RuleHeader.setBaseRegister(&r32);
         bits.RuleHeader.setName("RuleHeader");
+        bits.RuleHeader.addEnum("SOF", 0x0);
+        bits.RuleHeader.addEnum("IP", 0x1);
+        bits.RuleHeader.addEnum("TCP", 0x2);
+        bits.RuleHeader.addEnum("UDP", 0x3);
+        bits.RuleHeader.addEnum("DATA", 0x4);
+        bits.RuleHeader.addEnum("ICMPv4", 0x5);
+        bits.RuleHeader.addEnum("ICMPv6", 0x6);
+        bits.RuleHeader.addEnum("VLAN", 0x7);
+
         bits.RuleOp.setBaseRegister(&r32);
         bits.RuleOp.setName("RuleOp");
+        bits.RuleOp.addEnum("EQ", 0x0);
+        bits.RuleOp.addEnum("NE", 0x1);
+        bits.RuleOp.addEnum("GT", 0x2);
+        bits.RuleOp.addEnum("LT", 0x3);
+
         bits.RuleMap.setBaseRegister(&r32);
         bits.RuleMap.setName("RuleMap");
         bits.RuleDiscard.setBaseRegister(&r32);
@@ -399,6 +413,10 @@ typedef register_container RegFILTERSRuleSet_t {
         r32.setName("RuleSet");
         bits.Action.setBaseRegister(&r32);
         bits.Action.setName("Action");
+        bits.Action.addEnum("To APE Only", 0x0);
+        bits.Action.addEnum("To APE And Host", 0x1);
+        bits.Action.addEnum("Discard", 0x2);
+
         bits.Count.setBaseRegister(&r32);
         bits.Count.setName("Count");
         bits.Enable.setBaseRegister(&r32);

--- a/include/APE_NVIC.h
+++ b/include/APE_NVIC.h
@@ -124,6 +124,10 @@ typedef register_container RegNVICInterruptControlType_t {
         r32.setName("InterruptControlType");
         bits.INTLINESNUM.setBaseRegister(&r32);
         bits.INTLINESNUM.setName("INTLINESNUM");
+        bits.INTLINESNUM.addEnum("0 to 32", 0x0);
+        bits.INTLINESNUM.addEnum("33 to 64", 0x1);
+        bits.INTLINESNUM.addEnum("65 to 96", 0x2);
+
     }
     RegNVICInterruptControlType_t& operator=(const RegNVICInterruptControlType_t& other)
     {

--- a/include/APE_RX_PORT0.h
+++ b/include/APE_RX_PORT0.h
@@ -122,6 +122,12 @@ typedef register_container RegRX_PORTIn_t {
         r32.setName("In");
         bits.all.setBaseRegister(&r32);
         bits.all.setName("all");
+        bits.all.addEnum("Control Word", 0x0);
+        bits.all.addEnum("Additional Payload Word", 0x2);
+        bits.all.addEnum("First Payload Word", 0xc);
+        bits.all.addEnum("BLOCK_WORDS", 0x20);
+        bits.all.addEnum("BLOCK_BYTES", 0x80);
+
     }
     RegRX_PORTIn_t& operator=(const RegRX_PORTIn_t& other)
     {

--- a/include/APE_SHM.h
+++ b/include/APE_SHM.h
@@ -118,6 +118,8 @@ typedef register_container RegSHMSegSig_t {
         r32.setName("SegSig");
         bits.Sig.setBaseRegister(&r32);
         bits.Sig.setName("Sig");
+        bits.Sig.addEnum("LOADER", 0x10ad10ad);
+
     }
     RegSHMSegSig_t& operator=(const RegSHMSegSig_t& other)
     {
@@ -505,6 +507,11 @@ typedef register_container RegSHMLoaderCommand_t {
         r32.setName("LoaderCommand");
         bits.Command.setBaseRegister(&r32);
         bits.Command.setName("Command");
+        bits.Command.addEnum("NOP", 0x0);
+        bits.Command.addEnum("READ_MEM", 0x1);
+        bits.Command.addEnum("WRITE_MEM", 0x2);
+        bits.Command.addEnum("CALL", 0x3);
+
     }
     RegSHMLoaderCommand_t& operator=(const RegSHMLoaderCommand_t& other)
     {
@@ -601,6 +608,8 @@ typedef register_container RegSHMRcpuSegSig_t {
         r32.setName("RcpuSegSig");
         bits.Sig.setBaseRegister(&r32);
         bits.Sig.setName("Sig");
+        bits.Sig.addEnum("RCPU_MAGIC", 0x52435055);
+
     }
     RegSHMRcpuSegSig_t& operator=(const RegSHMRcpuSegSig_t& other)
     {
@@ -930,6 +939,8 @@ typedef register_container RegSHMRcpuCpmuStatus_t {
         r32.setName("RcpuCpmuStatus");
         bits.Address.setBaseRegister(&r32);
         bits.Address.setName("Address");
+        bits.Address.addEnum("ADDRESS", 0x362c);
+
         bits.Status.setBaseRegister(&r32);
         bits.Status.setName("Status");
     }
@@ -1271,8 +1282,17 @@ typedef register_container RegSHMEventStatus_t {
         bits.DriverEvent.setName("DriverEvent");
         bits.Command.setBaseRegister(&r32);
         bits.Command.setName("Command");
+        bits.Command.addEnum("State Change", 0x5);
+        bits.Command.addEnum("Scratchpad Read", 0x16);
+        bits.Command.addEnum("Scratchpad Write", 0x17);
+
         bits.State.setBaseRegister(&r32);
         bits.State.setName("State");
+        bits.State.addEnum("Start", 0x1);
+        bits.State.addEnum("Unload", 0x2);
+        bits.State.addEnum("WOL", 0x3);
+        bits.State.addEnum("Suspend", 0x4);
+
         bits.Pending.setBaseRegister(&r32);
         bits.Pending.setName("Pending");
     }

--- a/include/APE_SHM_CHANNEL0.h
+++ b/include/APE_SHM_CHANNEL0.h
@@ -1355,6 +1355,16 @@ typedef register_container RegSHM_CHANNELNcsiChannelStatus_t {
         bits.Linkup.setName("Linkup");
         bits.LinkStatus.setBaseRegister(&r32);
         bits.LinkStatus.setName("LinkStatus");
+        bits.LinkStatus.addEnum("No Link", 0x0);
+        bits.LinkStatus.addEnum("10BASE-T half-duplex", 0x1);
+        bits.LinkStatus.addEnum("10BASE-T full-duplex", 0x2);
+        bits.LinkStatus.addEnum("100BASE-TX half-duplex", 0x3);
+        bits.LinkStatus.addEnum("100BASE-T4", 0x4);
+        bits.LinkStatus.addEnum("100BASE-TX full-duplex", 0x5);
+        bits.LinkStatus.addEnum("1000BASE-T half-duplex", 0x6);
+        bits.LinkStatus.addEnum("1000BASE-T full-duplex", 0x7);
+        bits.LinkStatus.addEnum("10G-BASE-T", 0x8);
+
         bits.AutonegotiationEnabled.setBaseRegister(&r32);
         bits.AutonegotiationEnabled.setName("AutonegotiationEnabled");
         bits.AutonegotiationComplete.setBaseRegister(&r32);
@@ -1381,6 +1391,11 @@ typedef register_container RegSHM_CHANNELNcsiChannelStatus_t {
         bits.RXFlowControlFlag.setName("RXFlowControlFlag");
         bits.LinkPartnerAdvertisedFlowControl.setBaseRegister(&r32);
         bits.LinkPartnerAdvertisedFlowControl.setName("LinkPartnerAdvertisedFlowControl");
+        bits.LinkPartnerAdvertisedFlowControl.addEnum("Not Capable", 0x0);
+        bits.LinkPartnerAdvertisedFlowControl.addEnum("Symmetric Pause", 0x1);
+        bits.LinkPartnerAdvertisedFlowControl.addEnum("Asymmetric Pause", 0x2);
+        bits.LinkPartnerAdvertisedFlowControl.addEnum("Symmetric and Asymmetric Pause", 0x3);
+
         bits.SerDesLink.setBaseRegister(&r32);
         bits.SerDesLink.setName("SerDesLink");
         bits.OEMLinkStatusValid.setBaseRegister(&r32);

--- a/include/APE_TX_PORT0.h
+++ b/include/APE_TX_PORT0.h
@@ -124,6 +124,14 @@ typedef register_container RegTX_PORTOut_t {
         r32.setName("Out");
         bits.all.setBaseRegister(&r32);
         bits.all.setName("all");
+        bits.all.addEnum("Control Word", 0x0);
+        bits.all.addEnum("Additional Payload Word", 0x2);
+        bits.all.addEnum("Frame Len Word", 0x3);
+        bits.all.addEnum("Num Blocks Word", 0x9);
+        bits.all.addEnum("First Payload Word", 0xc);
+        bits.all.addEnum("BLOCK_WORDS", 0x20);
+        bits.all.addEnum("BLOCK_BYTES", 0x80);
+
     }
     RegTX_PORTOut_t& operator=(const RegTX_PORTOut_t& other)
     {

--- a/include/bcm5719_APE.h
+++ b/include/bcm5719_APE.h
@@ -420,12 +420,42 @@ typedef register_container RegAPEStatus_t {
         bits.LAN0Dstate.setName("LAN0Dstate");
         bits.BootMode.setBaseRegister(&r32);
         bits.BootMode.setName("BootMode");
+        bits.BootMode.addEnum("NVRAM", 0x0);
+        bits.BootMode.addEnum("Fast", 0x1);
+
         bits.LAN1Dstate.setBaseRegister(&r32);
         bits.LAN1Dstate.setName("LAN1Dstate");
         bits.BootStatusB.setBaseRegister(&r32);
         bits.BootStatusB.setName("BootStatusB");
+        bits.BootStatusB.addEnum("Prog 0", 0x0);
+        bits.BootStatusB.addEnum("Prog 1", 0x1);
+        bits.BootStatusB.addEnum("BPC Enter", 0x2);
+        bits.BootStatusB.addEnum("Decode", 0x3);
+        bits.BootStatusB.addEnum("Read NVRAM Header", 0x4);
+        bits.BootStatusB.addEnum("Read Code", 0x5);
+        bits.BootStatusB.addEnum("Jump", 0x6);
+        bits.BootStatusB.addEnum("Prog 7", 0x7);
+        bits.BootStatusB.addEnum("BPC Success", 0x8);
+
         bits.BootStatusA.setBaseRegister(&r32);
         bits.BootStatusA.setName("BootStatusA");
+        bits.BootStatusA.addEnum("None", 0x0);
+        bits.BootStatusA.addEnum("NMI Exception", 0x1);
+        bits.BootStatusA.addEnum("Fault Exception", 0x2);
+        bits.BootStatusA.addEnum("Memory Check", 0x3);
+        bits.BootStatusA.addEnum("Unknown 4", 0x4);
+        bits.BootStatusA.addEnum("Romloader Disabled", 0x5);
+        bits.BootStatusA.addEnum("Magic Number", 0x6);
+        bits.BootStatusA.addEnum("APE Init Code", 0x7);
+        bits.BootStatusA.addEnum("Header Checksum", 0x8);
+        bits.BootStatusA.addEnum("APE Header", 0x9);
+        bits.BootStatusA.addEnum("Image Checksum", 0xa);
+        bits.BootStatusA.addEnum("NVRAM Checksum", 0xb);
+        bits.BootStatusA.addEnum("Invalid Type", 0xc);
+        bits.BootStatusA.addEnum("ROM Loader Checksum", 0xd);
+        bits.BootStatusA.addEnum("Invalid Unzip Len", 0xe);
+        bits.BootStatusA.addEnum("Unknown F", 0xf);
+
     }
     RegAPEStatus_t& operator=(const RegAPEStatus_t& other)
     {
@@ -1043,6 +1073,11 @@ typedef register_container RegAPERxPoolRetire_t {
         bits.Retire.setName("Retire");
         bits.State.setBaseRegister(&r32);
         bits.State.setName("State");
+        bits.State.addEnum("Processing", 0x0);
+        bits.State.addEnum("Retired OK", 0x1);
+        bits.State.addEnum("Error: Full", 0x2);
+        bits.State.addEnum("Error: In Halt", 0x3);
+
         bits.Count.setBaseRegister(&r32);
         bits.Count.setName("Count");
     }
@@ -1233,10 +1268,17 @@ typedef register_container RegAPETxToNetBufferAllocator_t {
         r32.setName("TxToNetBufferAllocator0");
         bits.Index.setBaseRegister(&r32);
         bits.Index.setName("Index");
+        bits.Index.addEnum("Block Size", 0x80);
+
         bits.RequestAllocation.setBaseRegister(&r32);
         bits.RequestAllocation.setName("RequestAllocation");
         bits.State.setBaseRegister(&r32);
         bits.State.setName("State");
+        bits.State.addEnum("Processing", 0x0);
+        bits.State.addEnum("Allocation OK", 0x1);
+        bits.State.addEnum("Error: Empty", 0x2);
+        bits.State.addEnum("Error: In Halt", 0x3);
+
     }
     RegAPETxToNetBufferAllocator_t& operator=(const RegAPETxToNetBufferAllocator_t& other)
     {
@@ -1822,6 +1864,16 @@ typedef register_container RegAPECpuStatus_t {
         r32.setName("CpuStatus");
         bits.Status.setBaseRegister(&r32);
         bits.Status.setName("Status");
+        bits.Status.addEnum("Running", 0x0);
+        bits.Status.addEnum("Halted", 0x1);
+        bits.Status.addEnum("Locked Out", 0x2);
+        bits.Status.addEnum("Sleeping", 0x3);
+        bits.Status.addEnum("Deep Sleep", 0x4);
+        bits.Status.addEnum("Interrupt Pending", 0x8);
+        bits.Status.addEnum("Interrupt Entry", 0x9);
+        bits.Status.addEnum("Interrupt Exit", 0xa);
+        bits.Status.addEnum("Interrupt Return", 0xb);
+
         bits.ActiveInterrupt.setBaseRegister(&r32);
         bits.ActiveInterrupt.setName("ActiveInterrupt");
     }

--- a/include/bcm5719_DEVICE.h
+++ b/include/bcm5719_DEVICE.h
@@ -302,10 +302,20 @@ typedef register_container RegDEVICEMiscellaneousHostControl_t {
         bits.EnableTLPMinorErrorTolerance.setName("EnableTLPMinorErrorTolerance");
         bits.MetalRevID.setBaseRegister(&r32);
         bits.MetalRevID.setName("MetalRevID");
+        bits.MetalRevID.addEnum("0", 0x0);
+        bits.MetalRevID.addEnum("1", 0x1);
+        bits.MetalRevID.addEnum("2", 0x2);
+
         bits.AllLayerID.setBaseRegister(&r32);
         bits.AllLayerID.setName("AllLayerID");
+        bits.AllLayerID.addEnum("A", 0x0);
+        bits.AllLayerID.addEnum("B", 0x1);
+        bits.AllLayerID.addEnum("C", 0x2);
+
         bits.ProductID.setBaseRegister(&r32);
         bits.ProductID.setName("ProductID");
+        bits.ProductID.addEnum("New Product Mapping", 0xf);
+
     }
     RegDEVICEMiscellaneousHostControl_t& operator=(const RegDEVICEMiscellaneousHostControl_t& other)
     {
@@ -640,6 +650,9 @@ typedef register_container RegDEVICELinkStatusControl_t {
         r32.setName("LinkStatusControl");
         bits.NegotiatedLinkSpeed.setBaseRegister(&r32);
         bits.NegotiatedLinkSpeed.setName("NegotiatedLinkSpeed");
+        bits.NegotiatedLinkSpeed.addEnum("PCIe 1.0", 0x1);
+        bits.NegotiatedLinkSpeed.addEnum("PCIe 2.0", 0x2);
+
         bits.NegotiatedLinkWidth.setBaseRegister(&r32);
         bits.NegotiatedLinkWidth.setName("NegotiatedLinkWidth");
     }
@@ -953,6 +966,11 @@ typedef register_container RegDEVICEEmacMode_t {
         bits.HalfDuplex.setName("HalfDuplex");
         bits.PortMode.setBaseRegister(&r32);
         bits.PortMode.setName("PortMode");
+        bits.PortMode.addEnum("None", 0x0);
+        bits.PortMode.addEnum("10/100", 0x1);
+        bits.PortMode.addEnum("1000", 0x2);
+        bits.PortMode.addEnum("TBI", 0x3);
+
         bits.LoopbackMode.setBaseRegister(&r32);
         bits.LoopbackMode.setName("LoopbackMode");
         bits.TaggedMACControl.setBaseRegister(&r32);
@@ -1368,7 +1386,7 @@ typedef register_container RegDEVICEEmacEvent_t {
 #define     DEVICE_LED_CONTROL_LED_MODE_MAC 0x0u
 #define     DEVICE_LED_CONTROL_LED_MODE_PHY_MODE_1 0x1u
 #define     DEVICE_LED_CONTROL_LED_MODE_PHY_MODE_2 0x2u
-#define     DEVICE_LED_CONTROL_LED_MODE_PHY_MODE_1_ 0x3u
+#define     DEVICE_LED_CONTROL_LED_MODE_PHY_MODE_3 0x3u
 
 #define     DEVICE_LED_CONTROL_MAC_MODE_SHIFT 13u
 #define     DEVICE_LED_CONTROL_MAC_MODE_MASK  0x2000u
@@ -1502,6 +1520,11 @@ typedef register_container RegDEVICELedControl_t {
         bits.LEDStatusTraffic.setName("LEDStatusTraffic");
         bits.LEDMode.setBaseRegister(&r32);
         bits.LEDMode.setName("LEDMode");
+        bits.LEDMode.addEnum("MAC", 0x0);
+        bits.LEDMode.addEnum("PHY Mode 1", 0x1);
+        bits.LEDMode.addEnum("PHY Mode 2", 0x2);
+        bits.LEDMode.addEnum("PHY Mode 3", 0x3);
+
         bits.MACMode.setBaseRegister(&r32);
         bits.MACMode.setName("MACMode");
         bits.SharedTraffic_DIV_LinkLEDMode.setBaseRegister(&r32);
@@ -1912,8 +1935,20 @@ typedef register_container RegDEVICEMiiCommunication_t {
         bits.RegisterAddress.setName("RegisterAddress");
         bits.PHYAddress.setBaseRegister(&r32);
         bits.PHYAddress.setName("PHYAddress");
+        bits.PHYAddress.addEnum("PHY 0", 0x1);
+        bits.PHYAddress.addEnum("PHY 1", 0x2);
+        bits.PHYAddress.addEnum("PHY 2", 0x3);
+        bits.PHYAddress.addEnum("PHY 3", 0x4);
+        bits.PHYAddress.addEnum("SGMII 0", 0x8);
+        bits.PHYAddress.addEnum("SGMII 1", 0x9);
+        bits.PHYAddress.addEnum("SGMII 2", 0xa);
+        bits.PHYAddress.addEnum("SGMII 3", 0xb);
+
         bits.Command.setBaseRegister(&r32);
         bits.Command.setName("Command");
+        bits.Command.addEnum("Write", 0x1);
+        bits.Command.addEnum("Read", 0x2);
+
         bits.ReadFailed.setBaseRegister(&r32);
         bits.ReadFailed.setName("ReadFailed");
         bits.Start_DIV_Busy.setBaseRegister(&r32);
@@ -2901,6 +2936,9 @@ typedef register_container RegDEVICESgmiiStatus_t {
         bits.PauseTX.setName("PauseTX");
         bits.MediaSelectionMode.setBaseRegister(&r32);
         bits.MediaSelectionMode.setName("MediaSelectionMode");
+        bits.MediaSelectionMode.addEnum("Copper", 0x0);
+        bits.MediaSelectionMode.addEnum("SGMII", 0x1);
+
         bits.PCSCRSDetect.setBaseRegister(&r32);
         bits.PCSCRSDetect.setName("PCSCRSDetect");
         bits.ExternalCRSDetect.setBaseRegister(&r32);
@@ -3153,6 +3191,18 @@ typedef register_container RegDEVICELinkAwarePowerModeClockPolicy_t {
         r32.setName("LinkAwarePowerModeClockPolicy");
         bits.MACClockSwitch.setBaseRegister(&r32);
         bits.MACClockSwitch.setName("MACClockSwitch");
+        bits.MACClockSwitch.addEnum("60.0MHz", 0x1);
+        bits.MACClockSwitch.addEnum("30.0MHz", 0x3);
+        bits.MACClockSwitch.addEnum("15.0MHz", 0x5);
+        bits.MACClockSwitch.addEnum("7.5MHz", 0x7);
+        bits.MACClockSwitch.addEnum("3.75MHz", 0x9);
+        bits.MACClockSwitch.addEnum("12.5MHz", 0x11);
+        bits.MACClockSwitch.addEnum("6.25MHz", 0x13);
+        bits.MACClockSwitch.addEnum("3.125MHz", 0x15);
+        bits.MACClockSwitch.addEnum("1.563MHz", 0x17);
+        bits.MACClockSwitch.addEnum("781kHz", 0x19);
+        bits.MACClockSwitch.addEnum("12.5MHz/1.25MHz", 0x1f);
+
     }
     RegDEVICELinkAwarePowerModeClockPolicy_t& operator=(const RegDEVICELinkAwarePowerModeClockPolicy_t& other)
     {
@@ -3412,12 +3462,21 @@ typedef register_container RegDEVICEStatus_t {
         bits.LinkIdleStatus.setName("LinkIdleStatus");
         bits.EthernetLinkStatus.setBaseRegister(&r32);
         bits.EthernetLinkStatus.setName("EthernetLinkStatus");
+        bits.EthernetLinkStatus.addEnum("1000 Mb", 0x0);
+        bits.EthernetLinkStatus.addEnum("100 Mb", 0x1);
+        bits.EthernetLinkStatus.addEnum("10 Mb", 0x2);
+        bits.EthernetLinkStatus.addEnum("No Link", 0x3);
+
         bits.WOLMagicPacketDetectionEnablePort1.setBaseRegister(&r32);
         bits.WOLMagicPacketDetectionEnablePort1.setName("WOLMagicPacketDetectionEnablePort1");
         bits.WOLACPIDetectionEnablePort1.setBaseRegister(&r32);
         bits.WOLACPIDetectionEnablePort1.setName("WOLACPIDetectionEnablePort1");
         bits.APEStatus.setBaseRegister(&r32);
         bits.APEStatus.setName("APEStatus");
+        bits.APEStatus.addEnum("Active", 0x0);
+        bits.APEStatus.addEnum("Sleep", 0x1);
+        bits.APEStatus.addEnum("Deep Sleep", 0x2);
+
         bits.FunctionEnable.setBaseRegister(&r32);
         bits.FunctionEnable.setName("FunctionEnable");
         bits.FunctionNumber.setBaseRegister(&r32);
@@ -4314,8 +4373,18 @@ typedef register_container RegDEVICELsoNonlsoBdReadDmaCorruptionEnableControl_t 
         r32.setName("LsoNonlsoBdReadDmaCorruptionEnableControl");
         bits.PCIRequestBurstLengthforBDRDMAEngine.setBaseRegister(&r32);
         bits.PCIRequestBurstLengthforBDRDMAEngine.setName("PCIRequestBurstLengthforBDRDMAEngine");
+        bits.PCIRequestBurstLengthforBDRDMAEngine.addEnum("128B", 0x0);
+        bits.PCIRequestBurstLengthforBDRDMAEngine.addEnum("256B", 0x1);
+        bits.PCIRequestBurstLengthforBDRDMAEngine.addEnum("512B", 0x2);
+        bits.PCIRequestBurstLengthforBDRDMAEngine.addEnum("4K", 0x3);
+
         bits.PCIRequestBurstLengthforNonLSORDMAEngine.setBaseRegister(&r32);
         bits.PCIRequestBurstLengthforNonLSORDMAEngine.setName("PCIRequestBurstLengthforNonLSORDMAEngine");
+        bits.PCIRequestBurstLengthforNonLSORDMAEngine.addEnum("128B", 0x0);
+        bits.PCIRequestBurstLengthforNonLSORDMAEngine.addEnum("256B", 0x1);
+        bits.PCIRequestBurstLengthforNonLSORDMAEngine.addEnum("512B", 0x2);
+        bits.PCIRequestBurstLengthforNonLSORDMAEngine.addEnum("4K", 0x3);
+
     }
     RegDEVICELsoNonlsoBdReadDmaCorruptionEnableControl_t& operator=(const RegDEVICELsoNonlsoBdReadDmaCorruptionEnableControl_t& other)
     {
@@ -6086,14 +6155,35 @@ typedef register_container RegDEVICEPciPowerBudget0_t {
         bits.BasePower.setName("BasePower");
         bits.DataScale.setBaseRegister(&r32);
         bits.DataScale.setName("DataScale");
+        bits.DataScale.addEnum("1.0x", 0x0);
+        bits.DataScale.addEnum("0.1x", 0x1);
+        bits.DataScale.addEnum("0.01x", 0x2);
+        bits.DataScale.addEnum("0.001x", 0x3);
+
         bits.PMSubState.setBaseRegister(&r32);
         bits.PMSubState.setName("PMSubState");
         bits.PMState.setBaseRegister(&r32);
         bits.PMState.setName("PMState");
+        bits.PMState.addEnum("D0", 0x0);
+        bits.PMState.addEnum("D1", 0x1);
+        bits.PMState.addEnum("D2", 0x2);
+        bits.PMState.addEnum("D3", 0x3);
+
         bits.Type.setBaseRegister(&r32);
         bits.Type.setName("Type");
+        bits.Type.addEnum("PME Aux", 0x0);
+        bits.Type.addEnum("Auxiliary", 0x1);
+        bits.Type.addEnum("Idle", 0x2);
+        bits.Type.addEnum("Sustained", 0x3);
+        bits.Type.addEnum("Maximum", 0x7);
+
         bits.PowerRail.setBaseRegister(&r32);
         bits.PowerRail.setName("PowerRail");
+        bits.PowerRail.addEnum("Power 12V", 0x0);
+        bits.PowerRail.addEnum("Power 3.3V", 0x1);
+        bits.PowerRail.addEnum("Power 1.5V or 1.8V", 0x2);
+        bits.PowerRail.addEnum("Thermal", 0x7);
+
     }
     RegDEVICEPciPowerBudget0_t& operator=(const RegDEVICEPciPowerBudget0_t& other)
     {
@@ -6205,14 +6295,35 @@ typedef register_container RegDEVICEPciPowerBudget1_t {
         bits.BasePower.setName("BasePower");
         bits.DataScale.setBaseRegister(&r32);
         bits.DataScale.setName("DataScale");
+        bits.DataScale.addEnum("1.0x", 0x0);
+        bits.DataScale.addEnum("0.1x", 0x1);
+        bits.DataScale.addEnum("0.01x", 0x2);
+        bits.DataScale.addEnum("0.001x", 0x3);
+
         bits.PMSubState.setBaseRegister(&r32);
         bits.PMSubState.setName("PMSubState");
         bits.PMState.setBaseRegister(&r32);
         bits.PMState.setName("PMState");
+        bits.PMState.addEnum("D0", 0x0);
+        bits.PMState.addEnum("D1", 0x1);
+        bits.PMState.addEnum("D2", 0x2);
+        bits.PMState.addEnum("D3", 0x3);
+
         bits.Type.setBaseRegister(&r32);
         bits.Type.setName("Type");
+        bits.Type.addEnum("PME Aux", 0x0);
+        bits.Type.addEnum("Auxiliary", 0x1);
+        bits.Type.addEnum("Idle", 0x2);
+        bits.Type.addEnum("Sustained", 0x3);
+        bits.Type.addEnum("Maximum", 0x7);
+
         bits.PowerRail.setBaseRegister(&r32);
         bits.PowerRail.setName("PowerRail");
+        bits.PowerRail.addEnum("Power 12V", 0x0);
+        bits.PowerRail.addEnum("Power 3.3V", 0x1);
+        bits.PowerRail.addEnum("Power 1.5V or 1.8V", 0x2);
+        bits.PowerRail.addEnum("Thermal", 0x7);
+
     }
     RegDEVICEPciPowerBudget1_t& operator=(const RegDEVICEPciPowerBudget1_t& other)
     {
@@ -6324,14 +6435,35 @@ typedef register_container RegDEVICEPciPowerBudget2_t {
         bits.BasePower.setName("BasePower");
         bits.DataScale.setBaseRegister(&r32);
         bits.DataScale.setName("DataScale");
+        bits.DataScale.addEnum("1.0x", 0x0);
+        bits.DataScale.addEnum("0.1x", 0x1);
+        bits.DataScale.addEnum("0.01x", 0x2);
+        bits.DataScale.addEnum("0.001x", 0x3);
+
         bits.PMSubState.setBaseRegister(&r32);
         bits.PMSubState.setName("PMSubState");
         bits.PMState.setBaseRegister(&r32);
         bits.PMState.setName("PMState");
+        bits.PMState.addEnum("D0", 0x0);
+        bits.PMState.addEnum("D1", 0x1);
+        bits.PMState.addEnum("D2", 0x2);
+        bits.PMState.addEnum("D3", 0x3);
+
         bits.Type.setBaseRegister(&r32);
         bits.Type.setName("Type");
+        bits.Type.addEnum("PME Aux", 0x0);
+        bits.Type.addEnum("Auxiliary", 0x1);
+        bits.Type.addEnum("Idle", 0x2);
+        bits.Type.addEnum("Sustained", 0x3);
+        bits.Type.addEnum("Maximum", 0x7);
+
         bits.PowerRail.setBaseRegister(&r32);
         bits.PowerRail.setName("PowerRail");
+        bits.PowerRail.addEnum("Power 12V", 0x0);
+        bits.PowerRail.addEnum("Power 3.3V", 0x1);
+        bits.PowerRail.addEnum("Power 1.5V or 1.8V", 0x2);
+        bits.PowerRail.addEnum("Thermal", 0x7);
+
     }
     RegDEVICEPciPowerBudget2_t& operator=(const RegDEVICEPciPowerBudget2_t& other)
     {
@@ -6443,14 +6575,35 @@ typedef register_container RegDEVICEPciPowerBudget3_t {
         bits.BasePower.setName("BasePower");
         bits.DataScale.setBaseRegister(&r32);
         bits.DataScale.setName("DataScale");
+        bits.DataScale.addEnum("1.0x", 0x0);
+        bits.DataScale.addEnum("0.1x", 0x1);
+        bits.DataScale.addEnum("0.01x", 0x2);
+        bits.DataScale.addEnum("0.001x", 0x3);
+
         bits.PMSubState.setBaseRegister(&r32);
         bits.PMSubState.setName("PMSubState");
         bits.PMState.setBaseRegister(&r32);
         bits.PMState.setName("PMState");
+        bits.PMState.addEnum("D0", 0x0);
+        bits.PMState.addEnum("D1", 0x1);
+        bits.PMState.addEnum("D2", 0x2);
+        bits.PMState.addEnum("D3", 0x3);
+
         bits.Type.setBaseRegister(&r32);
         bits.Type.setName("Type");
+        bits.Type.addEnum("PME Aux", 0x0);
+        bits.Type.addEnum("Auxiliary", 0x1);
+        bits.Type.addEnum("Idle", 0x2);
+        bits.Type.addEnum("Sustained", 0x3);
+        bits.Type.addEnum("Maximum", 0x7);
+
         bits.PowerRail.setBaseRegister(&r32);
         bits.PowerRail.setName("PowerRail");
+        bits.PowerRail.addEnum("Power 12V", 0x0);
+        bits.PowerRail.addEnum("Power 3.3V", 0x1);
+        bits.PowerRail.addEnum("Power 1.5V or 1.8V", 0x2);
+        bits.PowerRail.addEnum("Thermal", 0x7);
+
     }
     RegDEVICEPciPowerBudget3_t& operator=(const RegDEVICEPciPowerBudget3_t& other)
     {
@@ -6562,14 +6715,35 @@ typedef register_container RegDEVICEPciPowerBudget4_t {
         bits.BasePower.setName("BasePower");
         bits.DataScale.setBaseRegister(&r32);
         bits.DataScale.setName("DataScale");
+        bits.DataScale.addEnum("1.0x", 0x0);
+        bits.DataScale.addEnum("0.1x", 0x1);
+        bits.DataScale.addEnum("0.01x", 0x2);
+        bits.DataScale.addEnum("0.001x", 0x3);
+
         bits.PMSubState.setBaseRegister(&r32);
         bits.PMSubState.setName("PMSubState");
         bits.PMState.setBaseRegister(&r32);
         bits.PMState.setName("PMState");
+        bits.PMState.addEnum("D0", 0x0);
+        bits.PMState.addEnum("D1", 0x1);
+        bits.PMState.addEnum("D2", 0x2);
+        bits.PMState.addEnum("D3", 0x3);
+
         bits.Type.setBaseRegister(&r32);
         bits.Type.setName("Type");
+        bits.Type.addEnum("PME Aux", 0x0);
+        bits.Type.addEnum("Auxiliary", 0x1);
+        bits.Type.addEnum("Idle", 0x2);
+        bits.Type.addEnum("Sustained", 0x3);
+        bits.Type.addEnum("Maximum", 0x7);
+
         bits.PowerRail.setBaseRegister(&r32);
         bits.PowerRail.setName("PowerRail");
+        bits.PowerRail.addEnum("Power 12V", 0x0);
+        bits.PowerRail.addEnum("Power 3.3V", 0x1);
+        bits.PowerRail.addEnum("Power 1.5V or 1.8V", 0x2);
+        bits.PowerRail.addEnum("Thermal", 0x7);
+
     }
     RegDEVICEPciPowerBudget4_t& operator=(const RegDEVICEPciPowerBudget4_t& other)
     {
@@ -6681,14 +6855,35 @@ typedef register_container RegDEVICEPciPowerBudget5_t {
         bits.BasePower.setName("BasePower");
         bits.DataScale.setBaseRegister(&r32);
         bits.DataScale.setName("DataScale");
+        bits.DataScale.addEnum("1.0x", 0x0);
+        bits.DataScale.addEnum("0.1x", 0x1);
+        bits.DataScale.addEnum("0.01x", 0x2);
+        bits.DataScale.addEnum("0.001x", 0x3);
+
         bits.PMSubState.setBaseRegister(&r32);
         bits.PMSubState.setName("PMSubState");
         bits.PMState.setBaseRegister(&r32);
         bits.PMState.setName("PMState");
+        bits.PMState.addEnum("D0", 0x0);
+        bits.PMState.addEnum("D1", 0x1);
+        bits.PMState.addEnum("D2", 0x2);
+        bits.PMState.addEnum("D3", 0x3);
+
         bits.Type.setBaseRegister(&r32);
         bits.Type.setName("Type");
+        bits.Type.addEnum("PME Aux", 0x0);
+        bits.Type.addEnum("Auxiliary", 0x1);
+        bits.Type.addEnum("Idle", 0x2);
+        bits.Type.addEnum("Sustained", 0x3);
+        bits.Type.addEnum("Maximum", 0x7);
+
         bits.PowerRail.setBaseRegister(&r32);
         bits.PowerRail.setName("PowerRail");
+        bits.PowerRail.addEnum("Power 12V", 0x0);
+        bits.PowerRail.addEnum("Power 3.3V", 0x1);
+        bits.PowerRail.addEnum("Power 1.5V or 1.8V", 0x2);
+        bits.PowerRail.addEnum("Thermal", 0x7);
+
     }
     RegDEVICEPciPowerBudget5_t& operator=(const RegDEVICEPciPowerBudget5_t& other)
     {
@@ -6800,14 +6995,35 @@ typedef register_container RegDEVICEPciPowerBudget6_t {
         bits.BasePower.setName("BasePower");
         bits.DataScale.setBaseRegister(&r32);
         bits.DataScale.setName("DataScale");
+        bits.DataScale.addEnum("1.0x", 0x0);
+        bits.DataScale.addEnum("0.1x", 0x1);
+        bits.DataScale.addEnum("0.01x", 0x2);
+        bits.DataScale.addEnum("0.001x", 0x3);
+
         bits.PMSubState.setBaseRegister(&r32);
         bits.PMSubState.setName("PMSubState");
         bits.PMState.setBaseRegister(&r32);
         bits.PMState.setName("PMState");
+        bits.PMState.addEnum("D0", 0x0);
+        bits.PMState.addEnum("D1", 0x1);
+        bits.PMState.addEnum("D2", 0x2);
+        bits.PMState.addEnum("D3", 0x3);
+
         bits.Type.setBaseRegister(&r32);
         bits.Type.setName("Type");
+        bits.Type.addEnum("PME Aux", 0x0);
+        bits.Type.addEnum("Auxiliary", 0x1);
+        bits.Type.addEnum("Idle", 0x2);
+        bits.Type.addEnum("Sustained", 0x3);
+        bits.Type.addEnum("Maximum", 0x7);
+
         bits.PowerRail.setBaseRegister(&r32);
         bits.PowerRail.setName("PowerRail");
+        bits.PowerRail.addEnum("Power 12V", 0x0);
+        bits.PowerRail.addEnum("Power 3.3V", 0x1);
+        bits.PowerRail.addEnum("Power 1.5V or 1.8V", 0x2);
+        bits.PowerRail.addEnum("Thermal", 0x7);
+
     }
     RegDEVICEPciPowerBudget6_t& operator=(const RegDEVICEPciPowerBudget6_t& other)
     {
@@ -6919,14 +7135,35 @@ typedef register_container RegDEVICEPciPowerBudget7_t {
         bits.BasePower.setName("BasePower");
         bits.DataScale.setBaseRegister(&r32);
         bits.DataScale.setName("DataScale");
+        bits.DataScale.addEnum("1.0x", 0x0);
+        bits.DataScale.addEnum("0.1x", 0x1);
+        bits.DataScale.addEnum("0.01x", 0x2);
+        bits.DataScale.addEnum("0.001x", 0x3);
+
         bits.PMSubState.setBaseRegister(&r32);
         bits.PMSubState.setName("PMSubState");
         bits.PMState.setBaseRegister(&r32);
         bits.PMState.setName("PMState");
+        bits.PMState.addEnum("D0", 0x0);
+        bits.PMState.addEnum("D1", 0x1);
+        bits.PMState.addEnum("D2", 0x2);
+        bits.PMState.addEnum("D3", 0x3);
+
         bits.Type.setBaseRegister(&r32);
         bits.Type.setName("Type");
+        bits.Type.addEnum("PME Aux", 0x0);
+        bits.Type.addEnum("Auxiliary", 0x1);
+        bits.Type.addEnum("Idle", 0x2);
+        bits.Type.addEnum("Sustained", 0x3);
+        bits.Type.addEnum("Maximum", 0x7);
+
         bits.PowerRail.setBaseRegister(&r32);
         bits.PowerRail.setName("PowerRail");
+        bits.PowerRail.addEnum("Power 12V", 0x0);
+        bits.PowerRail.addEnum("Power 3.3V", 0x1);
+        bits.PowerRail.addEnum("Power 1.5V or 1.8V", 0x2);
+        bits.PowerRail.addEnum("Thermal", 0x7);
+
     }
     RegDEVICEPciPowerBudget7_t& operator=(const RegDEVICEPciPowerBudget7_t& other)
     {
@@ -7736,14 +7973,43 @@ typedef register_container RegDEVICEEavRefClockControl_t {
         r32.setName("EavRefClockControl");
         bits.TimesyncGPIOMapping.setBaseRegister(&r32);
         bits.TimesyncGPIOMapping.setName("TimesyncGPIOMapping");
+        bits.TimesyncGPIOMapping.addEnum("Snap-Shot[0]", 0x0);
+        bits.TimesyncGPIOMapping.addEnum("Snap-Shot[1]", 0x1);
+        bits.TimesyncGPIOMapping.addEnum("Time Watchdog[0]", 0x2);
+        bits.TimesyncGPIOMapping.addEnum("Time Watchdog[1]", 0x3);
+
         bits.APEGPIO0Mapping.setBaseRegister(&r32);
         bits.APEGPIO0Mapping.setName("APEGPIO0Mapping");
+        bits.APEGPIO0Mapping.addEnum("Not Used", 0x0);
+        bits.APEGPIO0Mapping.addEnum("Snap-Shot[0]", 0x4);
+        bits.APEGPIO0Mapping.addEnum("Snap-Shot[1]", 0x5);
+        bits.APEGPIO0Mapping.addEnum("Time Watchdog[0]", 0x6);
+        bits.APEGPIO0Mapping.addEnum("Time Watchdog[1]", 0x7);
+
         bits.APEGPIO1Mapping.setBaseRegister(&r32);
         bits.APEGPIO1Mapping.setName("APEGPIO1Mapping");
+        bits.APEGPIO1Mapping.addEnum("Not Used", 0x0);
+        bits.APEGPIO1Mapping.addEnum("Snap-Shot[0]", 0x4);
+        bits.APEGPIO1Mapping.addEnum("Snap-Shot[1]", 0x5);
+        bits.APEGPIO1Mapping.addEnum("Time Watchdog[0]", 0x6);
+        bits.APEGPIO1Mapping.addEnum("Time Watchdog[1]", 0x7);
+
         bits.APEGPIO2Mapping.setBaseRegister(&r32);
         bits.APEGPIO2Mapping.setName("APEGPIO2Mapping");
+        bits.APEGPIO2Mapping.addEnum("Not Used", 0x0);
+        bits.APEGPIO2Mapping.addEnum("Snap-Shot[0]", 0x4);
+        bits.APEGPIO2Mapping.addEnum("Snap-Shot[1]", 0x5);
+        bits.APEGPIO2Mapping.addEnum("Time Watchdog[0]", 0x6);
+        bits.APEGPIO2Mapping.addEnum("Time Watchdog[1]", 0x7);
+
         bits.APEGPIO3Mapping.setBaseRegister(&r32);
         bits.APEGPIO3Mapping.setName("APEGPIO3Mapping");
+        bits.APEGPIO3Mapping.addEnum("Not Used", 0x0);
+        bits.APEGPIO3Mapping.addEnum("Snap-Shot[0]", 0x4);
+        bits.APEGPIO3Mapping.addEnum("Snap-Shot[1]", 0x5);
+        bits.APEGPIO3Mapping.addEnum("Time Watchdog[0]", 0x6);
+        bits.APEGPIO3Mapping.addEnum("Time Watchdog[1]", 0x7);
+
     }
     RegDEVICEEavRefClockControl_t& operator=(const RegDEVICEEavRefClockControl_t& other)
     {

--- a/include/bcm5719_GEN.h
+++ b/include/bcm5719_GEN.h
@@ -118,6 +118,8 @@ typedef register_container RegGENGenFwMbox_t {
         r32.setName("GenFwMbox");
         bits.MBOX.setBaseRegister(&r32);
         bits.MBOX.setName("MBOX");
+        bits.MBOX.addEnum("Bootcode Ready", 0xb49a89ab);
+
     }
     RegGENGenFwMbox_t& operator=(const RegGENGenFwMbox_t& other)
     {
@@ -166,6 +168,10 @@ typedef register_container RegGENGenDataSig_t {
         r32.setName("GenDataSig");
         bits.SIG.setBaseRegister(&r32);
         bits.SIG.setName("SIG");
+        bits.SIG.addEnum("Stage2 Magic Invalid", 0xbad0000);
+        bits.SIG.addEnum("Stage2 CRC Invalid", 0xbad0001);
+        bits.SIG.addEnum("Driver Ready", 0x4b657654);
+
     }
     RegGENGenDataSig_t& operator=(const RegGENGenDataSig_t& other)
     {
@@ -953,6 +959,11 @@ typedef register_container RegGENGenCfgHw_t {
         bits.AutoPowerdownEnable.setName("AutoPowerdownEnable");
         bits.SHASTALEDControl.setBaseRegister(&r32);
         bits.SHASTALEDControl.setName("SHASTALEDControl");
+        bits.SHASTALEDControl.addEnum("Legacy", 0x0);
+        bits.SHASTALEDControl.addEnum("Shared", 0x1);
+        bits.SHASTALEDControl.addEnum("MAC", 0x2);
+        bits.SHASTALEDControl.addEnum("Combo", 0x3);
+
         bits.TimeSyncModeEnable.setBaseRegister(&r32);
         bits.TimeSyncModeEnable.setName("TimeSyncModeEnable");
         bits.TimesyncGPIOMapping.setBaseRegister(&r32);

--- a/include/bcm5719_SHM.h
+++ b/include/bcm5719_SHM.h
@@ -118,6 +118,8 @@ typedef register_container RegSHMSegSig_t {
         r32.setName("SegSig");
         bits.Sig.setBaseRegister(&r32);
         bits.Sig.setName("Sig");
+        bits.Sig.addEnum("LOADER", 0x10ad10ad);
+
     }
     RegSHMSegSig_t& operator=(const RegSHMSegSig_t& other)
     {
@@ -505,6 +507,11 @@ typedef register_container RegSHMLoaderCommand_t {
         r32.setName("LoaderCommand");
         bits.Command.setBaseRegister(&r32);
         bits.Command.setName("Command");
+        bits.Command.addEnum("NOP", 0x0);
+        bits.Command.addEnum("READ_MEM", 0x1);
+        bits.Command.addEnum("WRITE_MEM", 0x2);
+        bits.Command.addEnum("CALL", 0x3);
+
     }
     RegSHMLoaderCommand_t& operator=(const RegSHMLoaderCommand_t& other)
     {
@@ -601,6 +608,8 @@ typedef register_container RegSHMRcpuSegSig_t {
         r32.setName("RcpuSegSig");
         bits.Sig.setBaseRegister(&r32);
         bits.Sig.setName("Sig");
+        bits.Sig.addEnum("RCPU_MAGIC", 0x52435055);
+
     }
     RegSHMRcpuSegSig_t& operator=(const RegSHMRcpuSegSig_t& other)
     {
@@ -930,6 +939,8 @@ typedef register_container RegSHMRcpuCpmuStatus_t {
         r32.setName("RcpuCpmuStatus");
         bits.Address.setBaseRegister(&r32);
         bits.Address.setName("Address");
+        bits.Address.addEnum("ADDRESS", 0x362c);
+
         bits.Status.setBaseRegister(&r32);
         bits.Status.setName("Status");
     }
@@ -1271,8 +1282,17 @@ typedef register_container RegSHMEventStatus_t {
         bits.DriverEvent.setName("DriverEvent");
         bits.Command.setBaseRegister(&r32);
         bits.Command.setName("Command");
+        bits.Command.addEnum("State Change", 0x5);
+        bits.Command.addEnum("Scratchpad Read", 0x16);
+        bits.Command.addEnum("Scratchpad Write", 0x17);
+
         bits.State.setBaseRegister(&r32);
         bits.State.setName("State");
+        bits.State.addEnum("Start", 0x1);
+        bits.State.addEnum("Unload", 0x2);
+        bits.State.addEnum("WOL", 0x3);
+        bits.State.addEnum("Suspend", 0x4);
+
         bits.Pending.setBaseRegister(&r32);
         bits.Pending.setName("Pending");
     }

--- a/include/bcm5719_SHM_CHANNEL0.h
+++ b/include/bcm5719_SHM_CHANNEL0.h
@@ -1355,6 +1355,16 @@ typedef register_container RegSHM_CHANNELNcsiChannelStatus_t {
         bits.Linkup.setName("Linkup");
         bits.LinkStatus.setBaseRegister(&r32);
         bits.LinkStatus.setName("LinkStatus");
+        bits.LinkStatus.addEnum("No Link", 0x0);
+        bits.LinkStatus.addEnum("10BASE-T half-duplex", 0x1);
+        bits.LinkStatus.addEnum("10BASE-T full-duplex", 0x2);
+        bits.LinkStatus.addEnum("100BASE-TX half-duplex", 0x3);
+        bits.LinkStatus.addEnum("100BASE-T4", 0x4);
+        bits.LinkStatus.addEnum("100BASE-TX full-duplex", 0x5);
+        bits.LinkStatus.addEnum("1000BASE-T half-duplex", 0x6);
+        bits.LinkStatus.addEnum("1000BASE-T full-duplex", 0x7);
+        bits.LinkStatus.addEnum("10G-BASE-T", 0x8);
+
         bits.AutonegotiationEnabled.setBaseRegister(&r32);
         bits.AutonegotiationEnabled.setName("AutonegotiationEnabled");
         bits.AutonegotiationComplete.setBaseRegister(&r32);
@@ -1381,6 +1391,11 @@ typedef register_container RegSHM_CHANNELNcsiChannelStatus_t {
         bits.RXFlowControlFlag.setName("RXFlowControlFlag");
         bits.LinkPartnerAdvertisedFlowControl.setBaseRegister(&r32);
         bits.LinkPartnerAdvertisedFlowControl.setName("LinkPartnerAdvertisedFlowControl");
+        bits.LinkPartnerAdvertisedFlowControl.addEnum("Not Capable", 0x0);
+        bits.LinkPartnerAdvertisedFlowControl.addEnum("Symmetric Pause", 0x1);
+        bits.LinkPartnerAdvertisedFlowControl.addEnum("Asymmetric Pause", 0x2);
+        bits.LinkPartnerAdvertisedFlowControl.addEnum("Symmetric and Asymmetric Pause", 0x3);
+
         bits.SerDesLink.setBaseRegister(&r32);
         bits.SerDesLink.setName("SerDesLink");
         bits.OEMLinkStatusValid.setBaseRegister(&r32);

--- a/ipxact/DEVICE.xml
+++ b/ipxact/DEVICE.xml
@@ -279,84 +279,6 @@
                     </ipxact:field>
                 </ipxact:register>
                 <ipxact:register>
-                    <ipxact:name>PCI_CLOCK_CONTROL</ipxact:name>
-                    <ipxact:description></ipxact:description>
-                    <ipxact:addressOffset>0x74</ipxact:addressOffset>
-                    <!-- LINK: registerDefinitionGroup: see 6.11.3, Register definition group -->
-                    <ipxact:size>32</ipxact:size>
-                    <ipxact:volatile>true</ipxact:volatile>
-                    <ipxact:field>
-                        <ipxact:name>Core Clk Disable</ipxact:name>
-                        <ipxact:description></ipxact:description>
-                        <ipxact:bitOffset>9</ipxact:bitOffset>
-                        <ipxact:bitWidth>1</ipxact:bitWidth>
-                        <ipxact:access>read-write</ipxact:access>
-                    </ipxact:field>
-                    <ipxact:field>
-                        <ipxact:name>RX Clk Disable</ipxact:name>
-                        <ipxact:description></ipxact:description>
-                        <ipxact:bitOffset>10</ipxact:bitOffset>
-                        <ipxact:bitWidth>1</ipxact:bitWidth>
-                        <ipxact:access>read-write</ipxact:access>
-                    </ipxact:field>
-                    <ipxact:field>
-                        <ipxact:name>TX Clk Disable</ipxact:name>
-                        <ipxact:description></ipxact:description>
-                        <ipxact:bitOffset>11</ipxact:bitOffset>
-                        <ipxact:bitWidth>1</ipxact:bitWidth>
-                        <ipxact:access>read-write</ipxact:access>
-                    </ipxact:field>
-                    <ipxact:field>
-                        <ipxact:name>Alt Clk</ipxact:name>
-                        <ipxact:description></ipxact:description>
-                        <ipxact:bitOffset>12</ipxact:bitOffset>
-                        <ipxact:bitWidth>1</ipxact:bitWidth>
-                        <ipxact:access>read-write</ipxact:access>
-                    </ipxact:field>
-                    <ipxact:field>
-                        <ipxact:name>Power Down PLL 133</ipxact:name>
-                        <ipxact:description></ipxact:description>
-                        <ipxact:bitOffset>15</ipxact:bitOffset>
-                        <ipxact:bitWidth>1</ipxact:bitWidth>
-                        <ipxact:access>read-write</ipxact:access>
-                    </ipxact:field>
-                    <ipxact:field>
-                        <ipxact:name>44MHz Core</ipxact:name>
-                        <ipxact:description></ipxact:description>
-                        <ipxact:bitOffset>18</ipxact:bitOffset>
-                        <ipxact:bitWidth>1</ipxact:bitWidth>
-                        <ipxact:access>read-write</ipxact:access>
-                    </ipxact:field>
-                    <ipxact:field>
-                        <ipxact:name>625 Core</ipxact:name>
-                        <ipxact:description></ipxact:description>
-                        <ipxact:bitOffset>20</ipxact:bitOffset>
-                        <ipxact:bitWidth>1</ipxact:bitWidth>
-                        <ipxact:access>read-write</ipxact:access>
-                    </ipxact:field>
-                    <ipxact:field>
-                        <ipxact:name>Force Clk Run</ipxact:name>
-                        <ipxact:description></ipxact:description>
-                        <ipxact:bitOffset>21</ipxact:bitOffset>
-                        <ipxact:bitWidth>1</ipxact:bitWidth>
-                        <ipxact:access>read-write</ipxact:access>
-                    </ipxact:field>
-                    <ipxact:field>
-                        <ipxact:name>Clk Run OEN</ipxact:name>
-                        <ipxact:description></ipxact:description>
-                        <ipxact:bitOffset>22</ipxact:bitOffset>
-                        <ipxact:bitWidth>1</ipxact:bitWidth>
-                        <ipxact:access>read-write</ipxact:access>
-                    </ipxact:field>
-                    <ipxact:field>
-                        <ipxact:name>Delay PCI Grant</ipxact:name>
-                        <ipxact:description></ipxact:description>
-                        <ipxact:bitOffset>31</ipxact:bitOffset>
-                        <ipxact:bitWidth>1</ipxact:bitWidth>
-                        <ipxact:access>read-write</ipxact:access>
-                    </ipxact:field>
-                </ipxact:register>
-                <ipxact:register>
                     <ipxact:name>REGISTER_BASE</ipxact:name>
                     <ipxact:description>Local controller memory address of a register than can be written or read by writing to the register data register.</ipxact:description>
                     <ipxact:addressOffset>0x78</ipxact:addressOffset>
@@ -912,18 +834,22 @@
                             <!-- LINK: enumeratedValue: see 6.11.10, Enumeration values -->
                             <ipxact:enumeratedValue>
                                 <ipxact:name>MAC</ipxact:name>
+                                <ipxact:description>LED signal is in active low (on) when link is established and is in high (off) when link is not established.</ipxact:description>
                                 <ipxact:value>0</ipxact:value>
                             </ipxact:enumeratedValue>
                             <ipxact:enumeratedValue>
                                 <ipxact:name>PHY Mode 1</ipxact:name>
+                                <ipxact:description>LED signal is in active low (on) when link is established and is in tristate (off) when link is not established.</ipxact:description>
                                 <ipxact:value>1</ipxact:value>
                             </ipxact:enumeratedValue>
                             <ipxact:enumeratedValue>
                                 <ipxact:name>PHY Mode 2</ipxact:name>
+                                <ipxact:description>LED signal is in active low (on) when link is established and is in high (off) when link is not established.</ipxact:description>
                                 <ipxact:value>2</ipxact:value>
                             </ipxact:enumeratedValue>
                             <ipxact:enumeratedValue>
-                                <ipxact:name>PHY Mode 1.</ipxact:name>
+                                <ipxact:name>PHY Mode 3</ipxact:name>
+                                <ipxact:description>Same as PHY mode 1</ipxact:description>
                                 <ipxact:value>3</ipxact:value>
                             </ipxact:enumeratedValue>
                         </ipxact:enumeratedValues>

--- a/ipxact/NVM.xml
+++ b/ipxact/NVM.xml
@@ -351,85 +351,113 @@
                     <ipxact:volatile>true</ipxact:volatile>
                     <ipxact:field>
                         <ipxact:name>Req Set0</ipxact:name>
-                        <ipxact:description></ipxact:description>
+                        <ipxact:description>Set Software Arbitration request Bit 0. This bit is set by writing a 1 to this bit position.</ipxact:description>
                         <ipxact:bitOffset>0</ipxact:bitOffset>
                         <ipxact:bitWidth>1</ipxact:bitWidth>
                         <ipxact:access>read-write</ipxact:access>
                     </ipxact:field>
                     <ipxact:field>
                         <ipxact:name>Req Set1</ipxact:name>
-                        <ipxact:description></ipxact:description>
+                        <ipxact:description>Set Software Arbitration request Bit 1. This bit is set by writing a 1 to this bit position.</ipxact:description>
                         <ipxact:bitOffset>1</ipxact:bitOffset>
                         <ipxact:bitWidth>1</ipxact:bitWidth>
                         <ipxact:access>read-write</ipxact:access>
                     </ipxact:field>
                     <ipxact:field>
                         <ipxact:name>Req Set2</ipxact:name>
-                        <ipxact:description></ipxact:description>
+                        <ipxact:description>Set Software Arbitration request Bit 2. This bit is set by writing a 1 to this bit position.</ipxact:description>
                         <ipxact:bitOffset>2</ipxact:bitOffset>
                         <ipxact:bitWidth>1</ipxact:bitWidth>
                         <ipxact:access>read-write</ipxact:access>
                     </ipxact:field>
                     <ipxact:field>
                         <ipxact:name>Req Set3</ipxact:name>
-                        <ipxact:description></ipxact:description>
+                        <ipxact:description>Set Software Arbitration request Bit 3. This bit is set by writing a 1 to this bit position.</ipxact:description>
                         <ipxact:bitOffset>3</ipxact:bitOffset>
                         <ipxact:bitWidth>1</ipxact:bitWidth>
                         <ipxact:access>read-write</ipxact:access>
                     </ipxact:field>
                     <ipxact:field>
                         <ipxact:name>Req Clr0</ipxact:name>
-                        <ipxact:description></ipxact:description>
+                        <ipxact:description>Clear Software Arbitration request Bit 0. This bit is cleared by writing a 1 to this bit position.</ipxact:description>
                         <ipxact:bitOffset>4</ipxact:bitOffset>
                         <ipxact:bitWidth>1</ipxact:bitWidth>
                         <ipxact:access>read-write</ipxact:access>
                     </ipxact:field>
                     <ipxact:field>
                         <ipxact:name>Req Clr1</ipxact:name>
-                        <ipxact:description></ipxact:description>
+                        <ipxact:description>Clear Software Arbitration request Bit 1. This bit is cleared by writing a 1 to this bit position.</ipxact:description>
                         <ipxact:bitOffset>5</ipxact:bitOffset>
                         <ipxact:bitWidth>1</ipxact:bitWidth>
                         <ipxact:access>read-write</ipxact:access>
                     </ipxact:field>
                     <ipxact:field>
                         <ipxact:name>Req Clr2</ipxact:name>
-                        <ipxact:description></ipxact:description>
+                        <ipxact:description>Clear Software Arbitration request Bit 2. This bit is cleared by writing a 1 to this bit position.</ipxact:description>
                         <ipxact:bitOffset>6</ipxact:bitOffset>
                         <ipxact:bitWidth>1</ipxact:bitWidth>
                         <ipxact:access>read-write</ipxact:access>
                     </ipxact:field>
                     <ipxact:field>
                         <ipxact:name>Req Clr3</ipxact:name>
-                        <ipxact:description></ipxact:description>
+                        <ipxact:description>Clear Software Arbitration request Bit 3. This bit is cleared by writing a 1 to this bit position.</ipxact:description>
                         <ipxact:bitOffset>7</ipxact:bitOffset>
                         <ipxact:bitWidth>1</ipxact:bitWidth>
                         <ipxact:access>read-write</ipxact:access>
                     </ipxact:field>
                     <ipxact:field>
                         <ipxact:name>Arb Won0</ipxact:name>
-                        <ipxact:description></ipxact:description>
+                        <ipxact:description>When arbitration is won, this bit will be read as 1, when an operation is complete, then the Req Clr0 must be written to clear this bit.</ipxact:description>
                         <ipxact:bitOffset>8</ipxact:bitOffset>
                         <ipxact:bitWidth>1</ipxact:bitWidth>
                         <ipxact:access>read-write</ipxact:access>
                     </ipxact:field>
                     <ipxact:field>
                         <ipxact:name>Arb Won1</ipxact:name>
-                        <ipxact:description></ipxact:description>
+                        <ipxact:description>When arbitration is won, this bit will be read as 1, when an operation is complete, then the Req Clr1 must be written to clear this bit.</ipxact:description>
                         <ipxact:bitOffset>9</ipxact:bitOffset>
                         <ipxact:bitWidth>1</ipxact:bitWidth>
                         <ipxact:access>read-write</ipxact:access>
                     </ipxact:field>
                     <ipxact:field>
                         <ipxact:name>Arb Won2</ipxact:name>
-                        <ipxact:description></ipxact:description>
+                        <ipxact:description>When arbitration is won, this bit will be read as 1, when an operation is complete, then the Req Clr2 must be written to clear this bit.</ipxact:description>
                         <ipxact:bitOffset>10</ipxact:bitOffset>
                         <ipxact:bitWidth>1</ipxact:bitWidth>
                         <ipxact:access>read-write</ipxact:access>
                     </ipxact:field>
                     <ipxact:field>
                         <ipxact:name>Arb Won3</ipxact:name>
-                        <ipxact:description></ipxact:description>
+                        <ipxact:description>When arbitration is won, this bit will be read as 1, when an operation is complete, then the Req Clr3 must be written to clear this bit.</ipxact:description>
                         <ipxact:bitOffset>11</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
+                    <ipxact:field>
+                        <ipxact:name>Req0</ipxact:name>
+                        <ipxact:description>This is the status of requester 0. When this bit is one, it means that Req Set0 has been set since Req Clr0.</ipxact:description>
+                        <ipxact:bitOffset>12</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
+                    <ipxact:field>
+                        <ipxact:name>Req1</ipxact:name>
+                        <ipxact:description>This is the status of requester 1. When this bit is one, it means that Req Set1 has been set since Req Clr1.</ipxact:description>
+                        <ipxact:bitOffset>13</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
+                    <ipxact:field>
+                        <ipxact:name>Req2</ipxact:name>
+                        <ipxact:description>This is the status of requester 2. When this bit is one, it means that Req Set2 has been set since Req Clr2.</ipxact:description>
+                        <ipxact:bitOffset>14</ipxact:bitOffset>
+                        <ipxact:bitWidth>1</ipxact:bitWidth>
+                        <ipxact:access>read-write</ipxact:access>
+                    </ipxact:field>
+                    <ipxact:field>
+                        <ipxact:name>Req3</ipxact:name>
+                        <ipxact:description>This is the status of requester 3. When this bit is one, it means that Req Set3 has been set since Req Clr3.</ipxact:description>
+                        <ipxact:bitOffset>15</ipxact:bitOffset>
                         <ipxact:bitWidth>1</ipxact:bitWidth>
                         <ipxact:access>read-write</ipxact:access>
                     </ipxact:field>

--- a/libs/MII/include/bcm5719_MII.h
+++ b/libs/MII/include/bcm5719_MII.h
@@ -221,6 +221,11 @@ typedef register_container RegMIIControl_t {
         bits.AutoNegotiationEnable.setName("AutoNegotiationEnable");
         bits.SpeedSelectLSB.setBaseRegister(&r16);
         bits.SpeedSelectLSB.setName("SpeedSelectLSB");
+        bits.SpeedSelectLSB.addEnum("10Mbit/s", 0x0);
+        bits.SpeedSelectLSB.addEnum("100Mbit/s", 0x1);
+        bits.SpeedSelectLSB.addEnum("1000Mbit/s", 0x2);
+        bits.SpeedSelectLSB.addEnum("Reserved", 0x3);
+
         bits.LoopbackMode.setBaseRegister(&r16);
         bits.LoopbackMode.setName("LoopbackMode");
         bits.Reset.setBaseRegister(&r16);
@@ -653,6 +658,8 @@ typedef register_container RegMIIAutonegotiationAdvertisement_t {
         r16.setName("AutonegotiationAdvertisement");
         bits.ProtocolSelect.setBaseRegister(&r16);
         bits.ProtocolSelect.setName("ProtocolSelect");
+        bits.ProtocolSelect.addEnum("IEEE 802.3", 0x1);
+
         bits._10BASE_THalfDuplexCapable.setBaseRegister(&r16);
         bits._10BASE_THalfDuplexCapable.setName("_10BASE_THalfDuplexCapable");
         bits._10BASE_TFullDuplexCapable.setBaseRegister(&r16);
@@ -932,6 +939,9 @@ typedef register_container RegMIIAutonegotiationExpansion_t {
         bits.ParallelDetectionFault.setName("ParallelDetectionFault");
         bits.NextPageReceiveLocation.setBaseRegister(&r16);
         bits.NextPageReceiveLocation.setName("NextPageReceiveLocation");
+        bits.NextPageReceiveLocation.addEnum("Next pages stored in register 0x05", 0x0);
+        bits.NextPageReceiveLocation.addEnum("Next pages stored in register 0x08", 0x1);
+
         bits.NextPageReceiveLocationCapable.setBaseRegister(&r16);
         bits.NextPageReceiveLocationCapable.setName("NextPageReceiveLocationCapable");
     }

--- a/libs/NVRam/bcm5719_NVM.h
+++ b/libs/NVRam/bcm5719_NVM.h
@@ -601,6 +601,13 @@ typedef register_container RegNVMNvmCfg1_t {
         bits.FlashSize.setName("FlashSize");
         bits.PageSize.setBaseRegister(&r32);
         bits.PageSize.setName("PageSize");
+        bits.PageSize.addEnum("256 bytes", 0x0);
+        bits.PageSize.addEnum("512 bytes", 0x1);
+        bits.PageSize.addEnum("1024 bytes", 0x2);
+        bits.PageSize.addEnum("2048 bytes", 0x3);
+        bits.PageSize.addEnum("4096 bytes", 0x4);
+        bits.PageSize.addEnum("264 bytes", 0x5);
+
     }
     RegNVMNvmCfg1_t& operator=(const RegNVMNvmCfg1_t& other)
     {
@@ -783,6 +790,22 @@ typedef register_container RegNVMNvmCfg3_t {
 #define     NVM_SOFTWARE_ARBITRATION_ARB_WON3_MASK  0x800u
 #define GET_NVM_SOFTWARE_ARBITRATION_ARB_WON3(__reg__)  (((__reg__) & 0x800) >> 11u)
 #define SET_NVM_SOFTWARE_ARBITRATION_ARB_WON3(__val__)  (((__val__) << 11u) & 0x800u)
+#define     NVM_SOFTWARE_ARBITRATION_REQ0_SHIFT 12u
+#define     NVM_SOFTWARE_ARBITRATION_REQ0_MASK  0x1000u
+#define GET_NVM_SOFTWARE_ARBITRATION_REQ0(__reg__)  (((__reg__) & 0x1000) >> 12u)
+#define SET_NVM_SOFTWARE_ARBITRATION_REQ0(__val__)  (((__val__) << 12u) & 0x1000u)
+#define     NVM_SOFTWARE_ARBITRATION_REQ1_SHIFT 13u
+#define     NVM_SOFTWARE_ARBITRATION_REQ1_MASK  0x2000u
+#define GET_NVM_SOFTWARE_ARBITRATION_REQ1(__reg__)  (((__reg__) & 0x2000) >> 13u)
+#define SET_NVM_SOFTWARE_ARBITRATION_REQ1(__val__)  (((__val__) << 13u) & 0x2000u)
+#define     NVM_SOFTWARE_ARBITRATION_REQ2_SHIFT 14u
+#define     NVM_SOFTWARE_ARBITRATION_REQ2_MASK  0x4000u
+#define GET_NVM_SOFTWARE_ARBITRATION_REQ2(__reg__)  (((__reg__) & 0x4000) >> 14u)
+#define SET_NVM_SOFTWARE_ARBITRATION_REQ2(__val__)  (((__val__) << 14u) & 0x4000u)
+#define     NVM_SOFTWARE_ARBITRATION_REQ3_SHIFT 15u
+#define     NVM_SOFTWARE_ARBITRATION_REQ3_MASK  0x8000u
+#define GET_NVM_SOFTWARE_ARBITRATION_REQ3(__reg__)  (((__reg__) & 0x8000) >> 15u)
+#define SET_NVM_SOFTWARE_ARBITRATION_REQ3(__val__)  (((__val__) << 15u) & 0x8000u)
 
 /** @brief Register definition for @ref NVM_t.SoftwareArbitration. */
 typedef register_container RegNVMSoftwareArbitration_t {
@@ -791,58 +814,74 @@ typedef register_container RegNVMSoftwareArbitration_t {
 
     BITFIELD_BEGIN(BCM5719_NVM_H_uint32_t, bits)
 #if defined(__LITTLE_ENDIAN__)
-        /** @brief  */
+        /** @brief Set Software Arbitration request Bit 0. This bit is set by writing a 1 to this bit position. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ReqSet0, 0, 1)
-        /** @brief  */
+        /** @brief Set Software Arbitration request Bit 1. This bit is set by writing a 1 to this bit position. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ReqSet1, 1, 1)
-        /** @brief  */
+        /** @brief Set Software Arbitration request Bit 2. This bit is set by writing a 1 to this bit position. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ReqSet2, 2, 1)
-        /** @brief  */
+        /** @brief Set Software Arbitration request Bit 3. This bit is set by writing a 1 to this bit position. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ReqSet3, 3, 1)
-        /** @brief  */
+        /** @brief Clear Software Arbitration request Bit 0. This bit is cleared by writing a 1 to this bit position. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ReqClr0, 4, 1)
-        /** @brief  */
+        /** @brief Clear Software Arbitration request Bit 1. This bit is cleared by writing a 1 to this bit position. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ReqClr1, 5, 1)
-        /** @brief  */
+        /** @brief Clear Software Arbitration request Bit 2. This bit is cleared by writing a 1 to this bit position. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ReqClr2, 6, 1)
-        /** @brief  */
+        /** @brief Clear Software Arbitration request Bit 3. This bit is cleared by writing a 1 to this bit position. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ReqClr3, 7, 1)
-        /** @brief  */
+        /** @brief When arbitration is won, this bit will be read as 1, when an operation is complete, then the Req Clr0 must be written to clear this bit. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ArbWon0, 8, 1)
-        /** @brief  */
+        /** @brief When arbitration is won, this bit will be read as 1, when an operation is complete, then the Req Clr1 must be written to clear this bit. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ArbWon1, 9, 1)
-        /** @brief  */
+        /** @brief When arbitration is won, this bit will be read as 1, when an operation is complete, then the Req Clr2 must be written to clear this bit. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ArbWon2, 10, 1)
-        /** @brief  */
+        /** @brief When arbitration is won, this bit will be read as 1, when an operation is complete, then the Req Clr3 must be written to clear this bit. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ArbWon3, 11, 1)
+        /** @brief This is the status of requester 0. When this bit is one, it means that Req Set0 has been set since Req Clr0. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, Req0, 12, 1)
+        /** @brief This is the status of requester 1. When this bit is one, it means that Req Set1 has been set since Req Clr1. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, Req1, 13, 1)
+        /** @brief This is the status of requester 2. When this bit is one, it means that Req Set2 has been set since Req Clr2. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, Req2, 14, 1)
+        /** @brief This is the status of requester 3. When this bit is one, it means that Req Set3 has been set since Req Clr3. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, Req3, 15, 1)
         /** @brief Padding */
-        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_31_12, 12, 20)
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_31_16, 16, 16)
 #elif defined(__BIG_ENDIAN__)
         /** @brief Padding */
-        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_31_12, 12, 20)
-        /** @brief  */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, reserved_31_16, 16, 16)
+        /** @brief This is the status of requester 3. When this bit is one, it means that Req Set3 has been set since Req Clr3. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, Req3, 15, 1)
+        /** @brief This is the status of requester 2. When this bit is one, it means that Req Set2 has been set since Req Clr2. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, Req2, 14, 1)
+        /** @brief This is the status of requester 1. When this bit is one, it means that Req Set1 has been set since Req Clr1. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, Req1, 13, 1)
+        /** @brief This is the status of requester 0. When this bit is one, it means that Req Set0 has been set since Req Clr0. */
+        BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, Req0, 12, 1)
+        /** @brief When arbitration is won, this bit will be read as 1, when an operation is complete, then the Req Clr3 must be written to clear this bit. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ArbWon3, 11, 1)
-        /** @brief  */
+        /** @brief When arbitration is won, this bit will be read as 1, when an operation is complete, then the Req Clr2 must be written to clear this bit. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ArbWon2, 10, 1)
-        /** @brief  */
+        /** @brief When arbitration is won, this bit will be read as 1, when an operation is complete, then the Req Clr1 must be written to clear this bit. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ArbWon1, 9, 1)
-        /** @brief  */
+        /** @brief When arbitration is won, this bit will be read as 1, when an operation is complete, then the Req Clr0 must be written to clear this bit. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ArbWon0, 8, 1)
-        /** @brief  */
+        /** @brief Clear Software Arbitration request Bit 3. This bit is cleared by writing a 1 to this bit position. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ReqClr3, 7, 1)
-        /** @brief  */
+        /** @brief Clear Software Arbitration request Bit 2. This bit is cleared by writing a 1 to this bit position. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ReqClr2, 6, 1)
-        /** @brief  */
+        /** @brief Clear Software Arbitration request Bit 1. This bit is cleared by writing a 1 to this bit position. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ReqClr1, 5, 1)
-        /** @brief  */
+        /** @brief Clear Software Arbitration request Bit 0. This bit is cleared by writing a 1 to this bit position. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ReqClr0, 4, 1)
-        /** @brief  */
+        /** @brief Set Software Arbitration request Bit 3. This bit is set by writing a 1 to this bit position. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ReqSet3, 3, 1)
-        /** @brief  */
+        /** @brief Set Software Arbitration request Bit 2. This bit is set by writing a 1 to this bit position. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ReqSet2, 2, 1)
-        /** @brief  */
+        /** @brief Set Software Arbitration request Bit 1. This bit is set by writing a 1 to this bit position. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ReqSet1, 1, 1)
-        /** @brief  */
+        /** @brief Set Software Arbitration request Bit 0. This bit is set by writing a 1 to this bit position. */
         BITFIELD_MEMBER(BCM5719_NVM_H_uint32_t, ReqSet0, 0, 1)
 #else
 #error Unknown Endian
@@ -883,6 +922,14 @@ typedef register_container RegNVMSoftwareArbitration_t {
         bits.ArbWon2.setName("ArbWon2");
         bits.ArbWon3.setBaseRegister(&r32);
         bits.ArbWon3.setName("ArbWon3");
+        bits.Req0.setBaseRegister(&r32);
+        bits.Req0.setName("Req0");
+        bits.Req1.setBaseRegister(&r32);
+        bits.Req1.setName("Req1");
+        bits.Req2.setBaseRegister(&r32);
+        bits.Req2.setName("Req2");
+        bits.Req3.setBaseRegister(&r32);
+        bits.Req3.setName("Req3");
     }
     RegNVMSoftwareArbitration_t& operator=(const RegNVMSoftwareArbitration_t& other)
     {
@@ -1153,6 +1200,16 @@ typedef register_container RegNVMAutoSenseStatus_t {
         bits.AutoConfigState.setName("AutoConfigState");
         bits.AutoDetectedDeviceID.setBaseRegister(&r32);
         bits.AutoDetectedDeviceID.setName("AutoDetectedDeviceID");
+        bits.AutoDetectedDeviceID.addEnum("AT45DB041D", 0x0);
+        bits.AutoDetectedDeviceID.addEnum("AT45DB021D", 0x3);
+        bits.AutoDetectedDeviceID.addEnum("AT45DB011D", 0x4);
+        bits.AutoDetectedDeviceID.addEnum("STM25PE40", 0x8);
+        bits.AutoDetectedDeviceID.addEnum("STM25PE20", 0xa);
+        bits.AutoDetectedDeviceID.addEnum("STM25PE10", 0xb);
+        bits.AutoDetectedDeviceID.addEnum("STM45PE10", 0xc);
+        bits.AutoDetectedDeviceID.addEnum("STM45PE20", 0xd);
+        bits.AutoDetectedDeviceID.addEnum("STM45PE40", 0xe);
+
     }
     RegNVMAutoSenseStatus_t& operator=(const RegNVMAutoSenseStatus_t& other)
     {

--- a/simulator/include/CXXRegister.h
+++ b/simulator/include/CXXRegister.h
@@ -49,9 +49,12 @@
 #include <stdio.h>
 #include <utility>
 #include <vector>
+#include <list>
 
 class CXXRegisterBase
 {
+private:
+    std::list<std::pair<int, const char*>> mEnums;
 public:
     CXXRegisterBase(unsigned int offset, unsigned int width)
     {
@@ -83,6 +86,28 @@ public:
         }
     }
 
+    const char* getEnum(int value)
+    {
+        std::list<std::pair<int, const char*>>::iterator it;
+        for (it = mEnums.begin(); it != mEnums.end();
+             it++)
+        {
+            if(value == (*it).first)
+            {
+                return (*it).second;
+            }
+        }
+        return NULL;
+    }
+
+    void addEnum(const char* name, int value)
+    {
+        if(!getEnum(value))
+        {
+            mEnums.push_back(std::make_pair(value, name));
+        }
+    }
+
     const char *getName(void)
     {
         return mName;
@@ -100,18 +125,24 @@ public:
 
     void print(unsigned int value, int indent = false)
     {
-        unsigned int masked = value & mMask;
+        unsigned int masked = (value & mMask) >> mBitPosition;
+        const char* enumstr = getEnum(masked);
         if (indent)
         {
             std::cout << std::right << std::setw(35) << mName << ": 0x"
-                      << std::hex << (masked >> mBitPosition) << std::endl;
+                      << std::hex << masked;
         }
         else
         {
             std::cout << std::endl
                       << std::left << std::setw(36) << mName << " 0x"
-                      << std::hex << (masked >> mBitPosition) << std::endl;
+                      << std::hex << masked;
         }
+        if(enumstr)
+        {
+            std::cout << " (" << enumstr << ")";
+        }
+        std::cout << std::endl;
     }
 
     void printAll(unsigned int value)


### PR DESCRIPTION
Add missing Req0-3 bits in the NVM software arbitration register.