### PR TITLE
Fix format string for parsing /sys/bus/pci/devices/ entries

### DIFF
--- a/simulator/HAL.cpp
+++ b/simulator/HAL.cpp
@@ -142,7 +142,7 @@ bool is_pci_function(const char *pci_path, int wanted_function)
     int bus = 0;
     int slot = 0;
     int function = 0;
-    if (4 == sscanf(pci_path, "%d:%d:%d.%d\n", &sys, &bus, &slot, &function))
+    if (4 == sscanf(pci_path, "%x:%x:%x.%d\n", &sys, &bus, &slot, &function))
     {
         if (wanted_function == function)
         {
@@ -223,6 +223,7 @@ bool initHAL(const char *pci_path, int wanted_function)
         pci_path = located_pci_path;
         if(!located_pci_path)
         {
+            fprintf(stderr, "Unable to find supported PCI device\n");
             return false;
         }
     }


### PR DESCRIPTION
The domain, bus, and device entries in the /sys/bus/pci/devices/ entries are hexidecimal, not decimal so the current code doesn't find devices past certain addresses in the PCI hierarchy.

As an example, without this patch, the code doesn't find this PCIe add-in card on my system:

b3:00.0 Ethernet controller [0200]: Broadcom Inc. and subsidiaries NetXtreme BCM5719 Gigabit Ethernet PCIe [14e4:1657] (rev 01)
b3:00.1 Ethernet controller [0200]: Broadcom Inc. and subsidiaries NetXtreme BCM5719 Gigabit Ethernet PCIe [14e4:1657] (rev 01)
b3:00.2 Ethernet controller [0200]: Broadcom Inc. and subsidiaries NetXtreme BCM5719 Gigabit Ethernet PCIe [14e4:1657] (rev 01)
b3:00.3 Ethernet controller [0200]: Broadcom Inc. and subsidiaries NetXtreme BCM5719 Gigabit Ethernet PCIe [14e4:1657] (rev 01)
