### PR TITLE
printf: Remove nvm access from the ape as it triggers a race conditio…

### DIFF
--- a/include/APE_SHM.h
+++ b/include/APE_SHM.h
@@ -10,7 +10,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// @copyright Copyright (c) 2018, Evan Lojewski
+/// @copyright Copyright (c) 2020, Evan Lojewski
 /// @cond
 ///
 /// All rights reserved.
@@ -1437,205 +1437,105 @@ typedef register_container RegSHMProtMac0Low_t {
 #endif /* CXX_SIMULATOR */
 } RegSHMProtMac0Low_t;
 
-#define REG_SHM_NCSI_SIG ((volatile APE_SHM_H_uint32_t*)0x60220800) /* Set to NCSI_MAGIC ('NCSI') by APE firmware. NOTE: all words in the NCSI section are available in the function 0 SHM area only. */
-/** @brief Register definition for @ref SHM_t.NcsiSig. */
-typedef register_container RegSHMNcsiSig_t {
+#define REG_SHM_RCPU_WRITE_POINTER ((volatile APE_SHM_H_uint32_t*)0x60220324) /* Index into the printf buffer for last valid byte. */
+/** @brief Register definition for @ref SHM_t.RcpuWritePointer. */
+typedef register_container RegSHMRcpuWritePointer_t {
     /** @brief 32bit direct register access. */
     APE_SHM_H_uint32_t r32;
 #ifdef CXX_SIMULATOR
     /** @brief Register name for use with the simulator. */
-    const char* getName(void) { return "NcsiSig"; }
+    const char* getName(void) { return "RcpuWritePointer"; }
 
     /** @brief Print register value. */
     void print(void) { r32.print(); }
 
-    RegSHMNcsiSig_t()
+    RegSHMRcpuWritePointer_t()
     {
-        /** @brief constructor for @ref SHM_t.NcsiSig. */
-        r32.setName("NcsiSig");
+        /** @brief constructor for @ref SHM_t.RcpuWritePointer. */
+        r32.setName("RcpuWritePointer");
     }
-    RegSHMNcsiSig_t& operator=(const RegSHMNcsiSig_t& other)
+    RegSHMRcpuWritePointer_t& operator=(const RegSHMRcpuWritePointer_t& other)
     {
         r32 = other.r32;
         return *this;
     }
 #endif /* CXX_SIMULATOR */
-} RegSHMNcsiSig_t;
+} RegSHMRcpuWritePointer_t;
 
-#define REG_SHM_NCSI_BUILD_TIME ((volatile APE_SHM_H_uint32_t*)0x60220810) /* ASCII string spanning three 32-bit words. Unused trailing bytes   are set to zero. */
-/** @brief Register definition for @ref SHM_t.NcsiBuildTime. */
-typedef register_container RegSHMNcsiBuildTime_t {
+#define REG_SHM_RCPU_HOST_READ_POINTER ((volatile APE_SHM_H_uint32_t*)0x60220328) /* Index into the printf buffer for last read byte. */
+/** @brief Register definition for @ref SHM_t.RcpuHostReadPointer. */
+typedef register_container RegSHMRcpuHostReadPointer_t {
     /** @brief 32bit direct register access. */
     APE_SHM_H_uint32_t r32;
 #ifdef CXX_SIMULATOR
     /** @brief Register name for use with the simulator. */
-    const char* getName(void) { return "NcsiBuildTime"; }
+    const char* getName(void) { return "RcpuHostReadPointer"; }
 
     /** @brief Print register value. */
     void print(void) { r32.print(); }
 
-    RegSHMNcsiBuildTime_t()
+    RegSHMRcpuHostReadPointer_t()
     {
-        /** @brief constructor for @ref SHM_t.NcsiBuildTime. */
-        r32.setName("NcsiBuildTime");
+        /** @brief constructor for @ref SHM_t.RcpuHostReadPointer. */
+        r32.setName("RcpuHostReadPointer");
     }
-    RegSHMNcsiBuildTime_t& operator=(const RegSHMNcsiBuildTime_t& other)
+    RegSHMRcpuHostReadPointer_t& operator=(const RegSHMRcpuHostReadPointer_t& other)
     {
         r32 = other.r32;
         return *this;
     }
 #endif /* CXX_SIMULATOR */
-} RegSHMNcsiBuildTime_t;
+} RegSHMRcpuHostReadPointer_t;
 
-#define REG_SHM_NCSI_BUILD_TIME_2 ((volatile APE_SHM_H_uint32_t*)0x60220814) /*  */
-/** @brief Register definition for @ref SHM_t.NcsiBuildTime2. */
-typedef register_container RegSHMNcsiBuildTime2_t {
+#define REG_SHM_RCPU_READ_POINTER ((volatile APE_SHM_H_uint32_t*)0x6022032c) /* Index into the printf buffer for last read byte. */
+/** @brief Register definition for @ref SHM_t.RcpuReadPointer. */
+typedef register_container RegSHMRcpuReadPointer_t {
     /** @brief 32bit direct register access. */
     APE_SHM_H_uint32_t r32;
 #ifdef CXX_SIMULATOR
     /** @brief Register name for use with the simulator. */
-    const char* getName(void) { return "NcsiBuildTime2"; }
+    const char* getName(void) { return "RcpuReadPointer"; }
 
     /** @brief Print register value. */
     void print(void) { r32.print(); }
 
-    RegSHMNcsiBuildTime2_t()
+    RegSHMRcpuReadPointer_t()
     {
-        /** @brief constructor for @ref SHM_t.NcsiBuildTime2. */
-        r32.setName("NcsiBuildTime2");
+        /** @brief constructor for @ref SHM_t.RcpuReadPointer. */
+        r32.setName("RcpuReadPointer");
     }
-    RegSHMNcsiBuildTime2_t& operator=(const RegSHMNcsiBuildTime2_t& other)
+    RegSHMRcpuReadPointer_t& operator=(const RegSHMRcpuReadPointer_t& other)
     {
         r32 = other.r32;
         return *this;
     }
 #endif /* CXX_SIMULATOR */
-} RegSHMNcsiBuildTime2_t;
+} RegSHMRcpuReadPointer_t;
 
-#define REG_SHM_NCSI_BUILD_TIME_3 ((volatile APE_SHM_H_uint32_t*)0x60220818) /*  */
-/** @brief Register definition for @ref SHM_t.NcsiBuildTime3. */
-typedef register_container RegSHMNcsiBuildTime3_t {
+#define REG_SHM_RCPU_PRINTF_BUFFER ((volatile APE_SHM_H_uint32_t*)0x60220330) /* Printf buffer from the APE to the Rcpu for NVRAM printout or the host */
+/** @brief Register definition for @ref SHM_t.RcpuPrintfBuffer. */
+typedef register_container RegSHMRcpuPrintfBuffer_t {
     /** @brief 32bit direct register access. */
     APE_SHM_H_uint32_t r32;
 #ifdef CXX_SIMULATOR
     /** @brief Register name for use with the simulator. */
-    const char* getName(void) { return "NcsiBuildTime3"; }
+    const char* getName(void) { return "RcpuPrintfBuffer"; }
 
     /** @brief Print register value. */
     void print(void) { r32.print(); }
 
-    RegSHMNcsiBuildTime3_t()
+    RegSHMRcpuPrintfBuffer_t()
     {
-        /** @brief constructor for @ref SHM_t.NcsiBuildTime3. */
-        r32.setName("NcsiBuildTime3");
+        /** @brief constructor for @ref SHM_t.RcpuPrintfBuffer. */
+        r32.setName("RcpuPrintfBuffer");
     }
-    RegSHMNcsiBuildTime3_t& operator=(const RegSHMNcsiBuildTime3_t& other)
+    RegSHMRcpuPrintfBuffer_t& operator=(const RegSHMRcpuPrintfBuffer_t& other)
     {
         r32 = other.r32;
         return *this;
     }
 #endif /* CXX_SIMULATOR */
-} RegSHMNcsiBuildTime3_t;
-
-#define REG_SHM_NCSI_BUILD_DATE ((volatile APE_SHM_H_uint32_t*)0x6022081c) /* ASCII string spanning three 32-bit words. Unused trailing bytes   are set to zero. */
-/** @brief Register definition for @ref SHM_t.NcsiBuildDate. */
-typedef register_container RegSHMNcsiBuildDate_t {
-    /** @brief 32bit direct register access. */
-    APE_SHM_H_uint32_t r32;
-#ifdef CXX_SIMULATOR
-    /** @brief Register name for use with the simulator. */
-    const char* getName(void) { return "NcsiBuildDate"; }
-
-    /** @brief Print register value. */
-    void print(void) { r32.print(); }
-
-    RegSHMNcsiBuildDate_t()
-    {
-        /** @brief constructor for @ref SHM_t.NcsiBuildDate. */
-        r32.setName("NcsiBuildDate");
-    }
-    RegSHMNcsiBuildDate_t& operator=(const RegSHMNcsiBuildDate_t& other)
-    {
-        r32 = other.r32;
-        return *this;
-    }
-#endif /* CXX_SIMULATOR */
-} RegSHMNcsiBuildDate_t;
-
-#define REG_SHM_NCSI_BUILD_DATE_2 ((volatile APE_SHM_H_uint32_t*)0x60220820) /*  */
-/** @brief Register definition for @ref SHM_t.NcsiBuildDate2. */
-typedef register_container RegSHMNcsiBuildDate2_t {
-    /** @brief 32bit direct register access. */
-    APE_SHM_H_uint32_t r32;
-#ifdef CXX_SIMULATOR
-    /** @brief Register name for use with the simulator. */
-    const char* getName(void) { return "NcsiBuildDate2"; }
-
-    /** @brief Print register value. */
-    void print(void) { r32.print(); }
-
-    RegSHMNcsiBuildDate2_t()
-    {
-        /** @brief constructor for @ref SHM_t.NcsiBuildDate2. */
-        r32.setName("NcsiBuildDate2");
-    }
-    RegSHMNcsiBuildDate2_t& operator=(const RegSHMNcsiBuildDate2_t& other)
-    {
-        r32 = other.r32;
-        return *this;
-    }
-#endif /* CXX_SIMULATOR */
-} RegSHMNcsiBuildDate2_t;
-
-#define REG_SHM_NCSI_BUILD_DATE_3 ((volatile APE_SHM_H_uint32_t*)0x60220824) /*  */
-/** @brief Register definition for @ref SHM_t.NcsiBuildDate3. */
-typedef register_container RegSHMNcsiBuildDate3_t {
-    /** @brief 32bit direct register access. */
-    APE_SHM_H_uint32_t r32;
-#ifdef CXX_SIMULATOR
-    /** @brief Register name for use with the simulator. */
-    const char* getName(void) { return "NcsiBuildDate3"; }
-
-    /** @brief Print register value. */
-    void print(void) { r32.print(); }
-
-    RegSHMNcsiBuildDate3_t()
-    {
-        /** @brief constructor for @ref SHM_t.NcsiBuildDate3. */
-        r32.setName("NcsiBuildDate3");
-    }
-    RegSHMNcsiBuildDate3_t& operator=(const RegSHMNcsiBuildDate3_t& other)
-    {
-        r32 = other.r32;
-        return *this;
-    }
-#endif /* CXX_SIMULATOR */
-} RegSHMNcsiBuildDate3_t;
-
-#define REG_SHM_CHIP_ID ((volatile APE_SHM_H_uint32_t*)0x60220890) /* The APE code copies the contents of Chip ID to this word */
-/** @brief Register definition for @ref SHM_t.ChipId. */
-typedef register_container RegSHMChipId_t {
-    /** @brief 32bit direct register access. */
-    APE_SHM_H_uint32_t r32;
-#ifdef CXX_SIMULATOR
-    /** @brief Register name for use with the simulator. */
-    const char* getName(void) { return "ChipId"; }
-
-    /** @brief Print register value. */
-    void print(void) { r32.print(); }
-
-    RegSHMChipId_t()
-    {
-        /** @brief constructor for @ref SHM_t.ChipId. */
-        r32.setName("ChipId");
-    }
-    RegSHMChipId_t& operator=(const RegSHMChipId_t& other)
-    {
-        r32 = other.r32;
-        return *this;
-    }
-#endif /* CXX_SIMULATOR */
-} RegSHMChipId_t;
+} RegSHMRcpuPrintfBuffer_t;
 
 /** @brief Component definition for @ref SHM. */
 typedef struct SHM_t {
@@ -1781,37 +1681,19 @@ typedef struct SHM_t {
     RegSHMProtMac0Low_t ProtMac0Low;
 
     /** @brief Reserved bytes to pad out data structure. */
-    APE_SHM_H_uint32_t reserved_796[313];
+    APE_SHM_H_uint32_t reserved_796[2];
 
-    /** @brief Set to NCSI_MAGIC ('NCSI') by APE firmware. NOTE: all words in the NCSI section are available in the function 0 SHM area only. */
-    RegSHMNcsiSig_t NcsiSig;
+    /** @brief Index into the printf buffer for last valid byte. */
+    RegSHMRcpuWritePointer_t RcpuWritePointer;
 
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_SHM_H_uint32_t reserved_2052[3];
+    /** @brief Index into the printf buffer for last read byte. */
+    RegSHMRcpuHostReadPointer_t RcpuHostReadPointer;
 
-    /** @brief ASCII string spanning three 32-bit words. Unused trailing bytes   are set to zero. */
-    RegSHMNcsiBuildTime_t NcsiBuildTime;
+    /** @brief Index into the printf buffer for last read byte. */
+    RegSHMRcpuReadPointer_t RcpuReadPointer;
 
-    /** @brief  */
-    RegSHMNcsiBuildTime2_t NcsiBuildTime2;
-
-    /** @brief  */
-    RegSHMNcsiBuildTime3_t NcsiBuildTime3;
-
-    /** @brief ASCII string spanning three 32-bit words. Unused trailing bytes   are set to zero. */
-    RegSHMNcsiBuildDate_t NcsiBuildDate;
-
-    /** @brief  */
-    RegSHMNcsiBuildDate2_t NcsiBuildDate2;
-
-    /** @brief  */
-    RegSHMNcsiBuildDate3_t NcsiBuildDate3;
-
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_SHM_H_uint32_t reserved_2088[26];
-
-    /** @brief The APE code copies the contents of Chip ID to this word */
-    RegSHMChipId_t ChipId;
+    /** @brief Printf buffer from the APE to the Rcpu for NVRAM printout or the host */
+    RegSHMRcpuPrintfBuffer_t RcpuPrintfBuffer[372];
 
 #ifdef CXX_SIMULATOR
     SHM_t()
@@ -1887,26 +1769,17 @@ typedef struct SHM_t {
         }
         ProtMac0High.r32.setComponentOffset(0x314);
         ProtMac0Low.r32.setComponentOffset(0x318);
-        for(int i = 0; i < 313; i++)
+        for(int i = 0; i < 2; i++)
         {
             reserved_796[i].setComponentOffset(0x31c + (i * 4));
         }
-        NcsiSig.r32.setComponentOffset(0x800);
-        for(int i = 0; i < 3; i++)
+        RcpuWritePointer.r32.setComponentOffset(0x324);
+        RcpuHostReadPointer.r32.setComponentOffset(0x328);
+        RcpuReadPointer.r32.setComponentOffset(0x32c);
+        for(int i = 0; i < 372; i++)
         {
-            reserved_2052[i].setComponentOffset(0x804 + (i * 4));
+            RcpuPrintfBuffer[i].r32.setComponentOffset(0x330 + (i * 4));
         }
-        NcsiBuildTime.r32.setComponentOffset(0x810);
-        NcsiBuildTime2.r32.setComponentOffset(0x814);
-        NcsiBuildTime3.r32.setComponentOffset(0x818);
-        NcsiBuildDate.r32.setComponentOffset(0x81c);
-        NcsiBuildDate2.r32.setComponentOffset(0x820);
-        NcsiBuildDate3.r32.setComponentOffset(0x824);
-        for(int i = 0; i < 26; i++)
-        {
-            reserved_2088[i].setComponentOffset(0x828 + (i * 4));
-        }
-        ChipId.r32.setComponentOffset(0x890);
     }
     void print()
     {
@@ -1981,26 +1854,17 @@ typedef struct SHM_t {
         }
         ProtMac0High.print();
         ProtMac0Low.print();
-        for(int i = 0; i < 313; i++)
+        for(int i = 0; i < 2; i++)
         {
             reserved_796[i].print();
         }
-        NcsiSig.print();
-        for(int i = 0; i < 3; i++)
+        RcpuWritePointer.print();
+        RcpuHostReadPointer.print();
+        RcpuReadPointer.print();
+        for(int i = 0; i < 372; i++)
         {
-            reserved_2052[i].print();
+            RcpuPrintfBuffer[i].print();
         }
-        NcsiBuildTime.print();
-        NcsiBuildTime2.print();
-        NcsiBuildTime3.print();
-        NcsiBuildDate.print();
-        NcsiBuildDate2.print();
-        NcsiBuildDate3.print();
-        for(int i = 0; i < 26; i++)
-        {
-            reserved_2088[i].print();
-        }
-        ChipId.print();
     }
     typedef uint32_t (*callback_t)(uint32_t, uint32_t, void*);
     callback_t mIndexReadCallback;
@@ -2029,7 +1893,7 @@ extern volatile SHM_t SHM;
 #undef BITFIELD_END
 
 #ifndef CXX_SIMULATOR
-_Static_assert(sizeof(SHM_t) == 2196, "sizeof(SHM_t) must be 2196");
+_Static_assert(sizeof(SHM_t) == 2304, "sizeof(SHM_t) must be 2304");
 #endif
 
 #endif /* !APE_SHM_H */

--- a/include/APE_SHM1.h
+++ b/include/APE_SHM1.h
@@ -10,7 +10,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// @copyright Copyright (c) 2018, Evan Lojewski
+/// @copyright Copyright (c) 2020, Evan Lojewski
 /// @cond
 ///
 /// All rights reserved.
@@ -121,14 +121,10 @@ typedef uint32_t APE_SHM1_H_uint32_t;
 #define REG_SHM1_PROT_MAGIC ((volatile APE_SHM1_H_uint32_t*)0x60221308) /* This is set to APE_PROT_MAGIC ('PROT') on all functions.  If it is 'PROT', the following fields (MAC0_HIGH/LOW) are valid */
 #define REG_SHM1_PROT_MAC0_HIGH ((volatile APE_SHM1_H_uint32_t*)0x60221314) /* High 16 bits of MAC address 0. Only valid if  */
 #define REG_SHM1_PROT_MAC0_LOW ((volatile APE_SHM1_H_uint32_t*)0x60221318) /* Low 16 bits of MAC address 0. */
-#define REG_SHM1_NCSI_SIG ((volatile APE_SHM1_H_uint32_t*)0x60221800) /* Set to NCSI_MAGIC ('NCSI') by APE firmware. NOTE: all words in the NCSI section are available in the function 0 SHM area only. */
-#define REG_SHM1_NCSI_BUILD_TIME ((volatile APE_SHM1_H_uint32_t*)0x60221810) /* ASCII string spanning three 32-bit words. Unused trailing bytes   are set to zero. */
-#define REG_SHM1_NCSI_BUILD_TIME_2 ((volatile APE_SHM1_H_uint32_t*)0x60221814) /*  */
-#define REG_SHM1_NCSI_BUILD_TIME_3 ((volatile APE_SHM1_H_uint32_t*)0x60221818) /*  */
-#define REG_SHM1_NCSI_BUILD_DATE ((volatile APE_SHM1_H_uint32_t*)0x6022181c) /* ASCII string spanning three 32-bit words. Unused trailing bytes   are set to zero. */
-#define REG_SHM1_NCSI_BUILD_DATE_2 ((volatile APE_SHM1_H_uint32_t*)0x60221820) /*  */
-#define REG_SHM1_NCSI_BUILD_DATE_3 ((volatile APE_SHM1_H_uint32_t*)0x60221824) /*  */
-#define REG_SHM1_CHIP_ID ((volatile APE_SHM1_H_uint32_t*)0x60221890) /* The APE code copies the contents of Chip ID to this word */
+#define REG_SHM1_RCPU_WRITE_POINTER ((volatile APE_SHM1_H_uint32_t*)0x60221324) /* Index into the printf buffer for last valid byte. */
+#define REG_SHM1_RCPU_HOST_READ_POINTER ((volatile APE_SHM1_H_uint32_t*)0x60221328) /* Index into the printf buffer for last read byte. */
+#define REG_SHM1_RCPU_READ_POINTER ((volatile APE_SHM1_H_uint32_t*)0x6022132c) /* Index into the printf buffer for last read byte. */
+#define REG_SHM1_RCPU_PRINTF_BUFFER ((volatile APE_SHM1_H_uint32_t*)0x60221330) /* Printf buffer from the APE to the Rcpu for NVRAM printout or the host */
 /** @brief Device SHM Registers, function 1 */
 extern volatile SHM_t SHM1;
 
@@ -144,7 +140,7 @@ extern volatile SHM_t SHM1;
 #undef BITFIELD_END
 
 #ifndef CXX_SIMULATOR
-_Static_assert(sizeof(SHM_t) == 2196, "sizeof(SHM_t) must be 2196");
+_Static_assert(sizeof(SHM_t) == 2304, "sizeof(SHM_t) must be 2304");
 #endif
 
 #endif /* !APE_SHM1_H */

--- a/include/APE_SHM2.h
+++ b/include/APE_SHM2.h
@@ -10,7 +10,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// @copyright Copyright (c) 2018, Evan Lojewski
+/// @copyright Copyright (c) 2020, Evan Lojewski
 /// @cond
 ///
 /// All rights reserved.
@@ -121,14 +121,10 @@ typedef uint32_t APE_SHM2_H_uint32_t;
 #define REG_SHM2_PROT_MAGIC ((volatile APE_SHM2_H_uint32_t*)0x60222308) /* This is set to APE_PROT_MAGIC ('PROT') on all functions.  If it is 'PROT', the following fields (MAC0_HIGH/LOW) are valid */
 #define REG_SHM2_PROT_MAC0_HIGH ((volatile APE_SHM2_H_uint32_t*)0x60222314) /* High 16 bits of MAC address 0. Only valid if  */
 #define REG_SHM2_PROT_MAC0_LOW ((volatile APE_SHM2_H_uint32_t*)0x60222318) /* Low 16 bits of MAC address 0. */
-#define REG_SHM2_NCSI_SIG ((volatile APE_SHM2_H_uint32_t*)0x60222800) /* Set to NCSI_MAGIC ('NCSI') by APE firmware. NOTE: all words in the NCSI section are available in the function 0 SHM area only. */
-#define REG_SHM2_NCSI_BUILD_TIME ((volatile APE_SHM2_H_uint32_t*)0x60222810) /* ASCII string spanning three 32-bit words. Unused trailing bytes   are set to zero. */
-#define REG_SHM2_NCSI_BUILD_TIME_2 ((volatile APE_SHM2_H_uint32_t*)0x60222814) /*  */
-#define REG_SHM2_NCSI_BUILD_TIME_3 ((volatile APE_SHM2_H_uint32_t*)0x60222818) /*  */
-#define REG_SHM2_NCSI_BUILD_DATE ((volatile APE_SHM2_H_uint32_t*)0x6022281c) /* ASCII string spanning three 32-bit words. Unused trailing bytes   are set to zero. */
-#define REG_SHM2_NCSI_BUILD_DATE_2 ((volatile APE_SHM2_H_uint32_t*)0x60222820) /*  */
-#define REG_SHM2_NCSI_BUILD_DATE_3 ((volatile APE_SHM2_H_uint32_t*)0x60222824) /*  */
-#define REG_SHM2_CHIP_ID ((volatile APE_SHM2_H_uint32_t*)0x60222890) /* The APE code copies the contents of Chip ID to this word */
+#define REG_SHM2_RCPU_WRITE_POINTER ((volatile APE_SHM2_H_uint32_t*)0x60222324) /* Index into the printf buffer for last valid byte. */
+#define REG_SHM2_RCPU_HOST_READ_POINTER ((volatile APE_SHM2_H_uint32_t*)0x60222328) /* Index into the printf buffer for last read byte. */
+#define REG_SHM2_RCPU_READ_POINTER ((volatile APE_SHM2_H_uint32_t*)0x6022232c) /* Index into the printf buffer for last read byte. */
+#define REG_SHM2_RCPU_PRINTF_BUFFER ((volatile APE_SHM2_H_uint32_t*)0x60222330) /* Printf buffer from the APE to the Rcpu for NVRAM printout or the host */
 /** @brief Device SHM Registers, function 2 */
 extern volatile SHM_t SHM2;
 
@@ -144,7 +140,7 @@ extern volatile SHM_t SHM2;
 #undef BITFIELD_END
 
 #ifndef CXX_SIMULATOR
-_Static_assert(sizeof(SHM_t) == 2196, "sizeof(SHM_t) must be 2196");
+_Static_assert(sizeof(SHM_t) == 2304, "sizeof(SHM_t) must be 2304");
 #endif
 
 #endif /* !APE_SHM2_H */

--- a/include/APE_SHM3.h
+++ b/include/APE_SHM3.h
@@ -10,7 +10,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// @copyright Copyright (c) 2018, Evan Lojewski
+/// @copyright Copyright (c) 2020, Evan Lojewski
 /// @cond
 ///
 /// All rights reserved.
@@ -121,14 +121,10 @@ typedef uint32_t APE_SHM3_H_uint32_t;
 #define REG_SHM3_PROT_MAGIC ((volatile APE_SHM3_H_uint32_t*)0x60223308) /* This is set to APE_PROT_MAGIC ('PROT') on all functions.  If it is 'PROT', the following fields (MAC0_HIGH/LOW) are valid */
 #define REG_SHM3_PROT_MAC0_HIGH ((volatile APE_SHM3_H_uint32_t*)0x60223314) /* High 16 bits of MAC address 0. Only valid if  */
 #define REG_SHM3_PROT_MAC0_LOW ((volatile APE_SHM3_H_uint32_t*)0x60223318) /* Low 16 bits of MAC address 0. */
-#define REG_SHM3_NCSI_SIG ((volatile APE_SHM3_H_uint32_t*)0x60223800) /* Set to NCSI_MAGIC ('NCSI') by APE firmware. NOTE: all words in the NCSI section are available in the function 0 SHM area only. */
-#define REG_SHM3_NCSI_BUILD_TIME ((volatile APE_SHM3_H_uint32_t*)0x60223810) /* ASCII string spanning three 32-bit words. Unused trailing bytes   are set to zero. */
-#define REG_SHM3_NCSI_BUILD_TIME_2 ((volatile APE_SHM3_H_uint32_t*)0x60223814) /*  */
-#define REG_SHM3_NCSI_BUILD_TIME_3 ((volatile APE_SHM3_H_uint32_t*)0x60223818) /*  */
-#define REG_SHM3_NCSI_BUILD_DATE ((volatile APE_SHM3_H_uint32_t*)0x6022381c) /* ASCII string spanning three 32-bit words. Unused trailing bytes   are set to zero. */
-#define REG_SHM3_NCSI_BUILD_DATE_2 ((volatile APE_SHM3_H_uint32_t*)0x60223820) /*  */
-#define REG_SHM3_NCSI_BUILD_DATE_3 ((volatile APE_SHM3_H_uint32_t*)0x60223824) /*  */
-#define REG_SHM3_CHIP_ID ((volatile APE_SHM3_H_uint32_t*)0x60223890) /* The APE code copies the contents of Chip ID to this word */
+#define REG_SHM3_RCPU_WRITE_POINTER ((volatile APE_SHM3_H_uint32_t*)0x60223324) /* Index into the printf buffer for last valid byte. */
+#define REG_SHM3_RCPU_HOST_READ_POINTER ((volatile APE_SHM3_H_uint32_t*)0x60223328) /* Index into the printf buffer for last read byte. */
+#define REG_SHM3_RCPU_READ_POINTER ((volatile APE_SHM3_H_uint32_t*)0x6022332c) /* Index into the printf buffer for last read byte. */
+#define REG_SHM3_RCPU_PRINTF_BUFFER ((volatile APE_SHM3_H_uint32_t*)0x60223330) /* Printf buffer from the APE to the Rcpu for NVRAM printout or the host */
 /** @brief Device SHM Registers, function 3 */
 extern volatile SHM_t SHM3;
 
@@ -144,7 +140,7 @@ extern volatile SHM_t SHM3;
 #undef BITFIELD_END
 
 #ifndef CXX_SIMULATOR
-_Static_assert(sizeof(SHM_t) == 2196, "sizeof(SHM_t) must be 2196");
+_Static_assert(sizeof(SHM_t) == 2304, "sizeof(SHM_t) must be 2304");
 #endif
 
 #endif /* !APE_SHM3_H */

--- a/include/bcm5719_SHM.h
+++ b/include/bcm5719_SHM.h
@@ -10,7 +10,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// @copyright Copyright (c) 2018, Evan Lojewski
+/// @copyright Copyright (c) 2020, Evan Lojewski
 /// @cond
 ///
 /// All rights reserved.
@@ -1437,205 +1437,105 @@ typedef register_container RegSHMProtMac0Low_t {
 #endif /* CXX_SIMULATOR */
 } RegSHMProtMac0Low_t;
 
-#define REG_SHM_NCSI_SIG ((volatile BCM5719_SHM_H_uint32_t*)0xc0014800) /* Set to NCSI_MAGIC ('NCSI') by APE firmware. NOTE: all words in the NCSI section are available in the function 0 SHM area only. */
-/** @brief Register definition for @ref SHM_t.NcsiSig. */
-typedef register_container RegSHMNcsiSig_t {
+#define REG_SHM_RCPU_WRITE_POINTER ((volatile BCM5719_SHM_H_uint32_t*)0xc0014324) /* Index into the printf buffer for last valid byte. */
+/** @brief Register definition for @ref SHM_t.RcpuWritePointer. */
+typedef register_container RegSHMRcpuWritePointer_t {
     /** @brief 32bit direct register access. */
     BCM5719_SHM_H_uint32_t r32;
 #ifdef CXX_SIMULATOR
     /** @brief Register name for use with the simulator. */
-    const char* getName(void) { return "NcsiSig"; }
+    const char* getName(void) { return "RcpuWritePointer"; }
 
     /** @brief Print register value. */
     void print(void) { r32.print(); }
 
-    RegSHMNcsiSig_t()
+    RegSHMRcpuWritePointer_t()
     {
-        /** @brief constructor for @ref SHM_t.NcsiSig. */
-        r32.setName("NcsiSig");
+        /** @brief constructor for @ref SHM_t.RcpuWritePointer. */
+        r32.setName("RcpuWritePointer");
     }
-    RegSHMNcsiSig_t& operator=(const RegSHMNcsiSig_t& other)
+    RegSHMRcpuWritePointer_t& operator=(const RegSHMRcpuWritePointer_t& other)
     {
         r32 = other.r32;
         return *this;
     }
 #endif /* CXX_SIMULATOR */
-} RegSHMNcsiSig_t;
+} RegSHMRcpuWritePointer_t;
 
-#define REG_SHM_NCSI_BUILD_TIME ((volatile BCM5719_SHM_H_uint32_t*)0xc0014810) /* ASCII string spanning three 32-bit words. Unused trailing bytes   are set to zero. */
-/** @brief Register definition for @ref SHM_t.NcsiBuildTime. */
-typedef register_container RegSHMNcsiBuildTime_t {
+#define REG_SHM_RCPU_HOST_READ_POINTER ((volatile BCM5719_SHM_H_uint32_t*)0xc0014328) /* Index into the printf buffer for last read byte. */
+/** @brief Register definition for @ref SHM_t.RcpuHostReadPointer. */
+typedef register_container RegSHMRcpuHostReadPointer_t {
     /** @brief 32bit direct register access. */
     BCM5719_SHM_H_uint32_t r32;
 #ifdef CXX_SIMULATOR
     /** @brief Register name for use with the simulator. */
-    const char* getName(void) { return "NcsiBuildTime"; }
+    const char* getName(void) { return "RcpuHostReadPointer"; }
 
     /** @brief Print register value. */
     void print(void) { r32.print(); }
 
-    RegSHMNcsiBuildTime_t()
+    RegSHMRcpuHostReadPointer_t()
     {
-        /** @brief constructor for @ref SHM_t.NcsiBuildTime. */
-        r32.setName("NcsiBuildTime");
+        /** @brief constructor for @ref SHM_t.RcpuHostReadPointer. */
+        r32.setName("RcpuHostReadPointer");
     }
-    RegSHMNcsiBuildTime_t& operator=(const RegSHMNcsiBuildTime_t& other)
+    RegSHMRcpuHostReadPointer_t& operator=(const RegSHMRcpuHostReadPointer_t& other)
     {
         r32 = other.r32;
         return *this;
     }
 #endif /* CXX_SIMULATOR */
-} RegSHMNcsiBuildTime_t;
+} RegSHMRcpuHostReadPointer_t;
 
-#define REG_SHM_NCSI_BUILD_TIME_2 ((volatile BCM5719_SHM_H_uint32_t*)0xc0014814) /*  */
-/** @brief Register definition for @ref SHM_t.NcsiBuildTime2. */
-typedef register_container RegSHMNcsiBuildTime2_t {
+#define REG_SHM_RCPU_READ_POINTER ((volatile BCM5719_SHM_H_uint32_t*)0xc001432c) /* Index into the printf buffer for last read byte. */
+/** @brief Register definition for @ref SHM_t.RcpuReadPointer. */
+typedef register_container RegSHMRcpuReadPointer_t {
     /** @brief 32bit direct register access. */
     BCM5719_SHM_H_uint32_t r32;
 #ifdef CXX_SIMULATOR
     /** @brief Register name for use with the simulator. */
-    const char* getName(void) { return "NcsiBuildTime2"; }
+    const char* getName(void) { return "RcpuReadPointer"; }
 
     /** @brief Print register value. */
     void print(void) { r32.print(); }
 
-    RegSHMNcsiBuildTime2_t()
+    RegSHMRcpuReadPointer_t()
     {
-        /** @brief constructor for @ref SHM_t.NcsiBuildTime2. */
-        r32.setName("NcsiBuildTime2");
+        /** @brief constructor for @ref SHM_t.RcpuReadPointer. */
+        r32.setName("RcpuReadPointer");
     }
-    RegSHMNcsiBuildTime2_t& operator=(const RegSHMNcsiBuildTime2_t& other)
+    RegSHMRcpuReadPointer_t& operator=(const RegSHMRcpuReadPointer_t& other)
     {
         r32 = other.r32;
         return *this;
     }
 #endif /* CXX_SIMULATOR */
-} RegSHMNcsiBuildTime2_t;
+} RegSHMRcpuReadPointer_t;
 
-#define REG_SHM_NCSI_BUILD_TIME_3 ((volatile BCM5719_SHM_H_uint32_t*)0xc0014818) /*  */
-/** @brief Register definition for @ref SHM_t.NcsiBuildTime3. */
-typedef register_container RegSHMNcsiBuildTime3_t {
+#define REG_SHM_RCPU_PRINTF_BUFFER ((volatile BCM5719_SHM_H_uint32_t*)0xc0014330) /* Printf buffer from the APE to the Rcpu for NVRAM printout or the host */
+/** @brief Register definition for @ref SHM_t.RcpuPrintfBuffer. */
+typedef register_container RegSHMRcpuPrintfBuffer_t {
     /** @brief 32bit direct register access. */
     BCM5719_SHM_H_uint32_t r32;
 #ifdef CXX_SIMULATOR
     /** @brief Register name for use with the simulator. */
-    const char* getName(void) { return "NcsiBuildTime3"; }
+    const char* getName(void) { return "RcpuPrintfBuffer"; }
 
     /** @brief Print register value. */
     void print(void) { r32.print(); }
 
-    RegSHMNcsiBuildTime3_t()
+    RegSHMRcpuPrintfBuffer_t()
     {
-        /** @brief constructor for @ref SHM_t.NcsiBuildTime3. */
-        r32.setName("NcsiBuildTime3");
+        /** @brief constructor for @ref SHM_t.RcpuPrintfBuffer. */
+        r32.setName("RcpuPrintfBuffer");
     }
-    RegSHMNcsiBuildTime3_t& operator=(const RegSHMNcsiBuildTime3_t& other)
+    RegSHMRcpuPrintfBuffer_t& operator=(const RegSHMRcpuPrintfBuffer_t& other)
     {
         r32 = other.r32;
         return *this;
     }
 #endif /* CXX_SIMULATOR */
-} RegSHMNcsiBuildTime3_t;
-
-#define REG_SHM_NCSI_BUILD_DATE ((volatile BCM5719_SHM_H_uint32_t*)0xc001481c) /* ASCII string spanning three 32-bit words. Unused trailing bytes   are set to zero. */
-/** @brief Register definition for @ref SHM_t.NcsiBuildDate. */
-typedef register_container RegSHMNcsiBuildDate_t {
-    /** @brief 32bit direct register access. */
-    BCM5719_SHM_H_uint32_t r32;
-#ifdef CXX_SIMULATOR
-    /** @brief Register name for use with the simulator. */
-    const char* getName(void) { return "NcsiBuildDate"; }
-
-    /** @brief Print register value. */
-    void print(void) { r32.print(); }
-
-    RegSHMNcsiBuildDate_t()
-    {
-        /** @brief constructor for @ref SHM_t.NcsiBuildDate. */
-        r32.setName("NcsiBuildDate");
-    }
-    RegSHMNcsiBuildDate_t& operator=(const RegSHMNcsiBuildDate_t& other)
-    {
-        r32 = other.r32;
-        return *this;
-    }
-#endif /* CXX_SIMULATOR */
-} RegSHMNcsiBuildDate_t;
-
-#define REG_SHM_NCSI_BUILD_DATE_2 ((volatile BCM5719_SHM_H_uint32_t*)0xc0014820) /*  */
-/** @brief Register definition for @ref SHM_t.NcsiBuildDate2. */
-typedef register_container RegSHMNcsiBuildDate2_t {
-    /** @brief 32bit direct register access. */
-    BCM5719_SHM_H_uint32_t r32;
-#ifdef CXX_SIMULATOR
-    /** @brief Register name for use with the simulator. */
-    const char* getName(void) { return "NcsiBuildDate2"; }
-
-    /** @brief Print register value. */
-    void print(void) { r32.print(); }
-
-    RegSHMNcsiBuildDate2_t()
-    {
-        /** @brief constructor for @ref SHM_t.NcsiBuildDate2. */
-        r32.setName("NcsiBuildDate2");
-    }
-    RegSHMNcsiBuildDate2_t& operator=(const RegSHMNcsiBuildDate2_t& other)
-    {
-        r32 = other.r32;
-        return *this;
-    }
-#endif /* CXX_SIMULATOR */
-} RegSHMNcsiBuildDate2_t;
-
-#define REG_SHM_NCSI_BUILD_DATE_3 ((volatile BCM5719_SHM_H_uint32_t*)0xc0014824) /*  */
-/** @brief Register definition for @ref SHM_t.NcsiBuildDate3. */
-typedef register_container RegSHMNcsiBuildDate3_t {
-    /** @brief 32bit direct register access. */
-    BCM5719_SHM_H_uint32_t r32;
-#ifdef CXX_SIMULATOR
-    /** @brief Register name for use with the simulator. */
-    const char* getName(void) { return "NcsiBuildDate3"; }
-
-    /** @brief Print register value. */
-    void print(void) { r32.print(); }
-
-    RegSHMNcsiBuildDate3_t()
-    {
-        /** @brief constructor for @ref SHM_t.NcsiBuildDate3. */
-        r32.setName("NcsiBuildDate3");
-    }
-    RegSHMNcsiBuildDate3_t& operator=(const RegSHMNcsiBuildDate3_t& other)
-    {
-        r32 = other.r32;
-        return *this;
-    }
-#endif /* CXX_SIMULATOR */
-} RegSHMNcsiBuildDate3_t;
-
-#define REG_SHM_CHIP_ID ((volatile BCM5719_SHM_H_uint32_t*)0xc0014890) /* The APE code copies the contents of Chip ID to this word */
-/** @brief Register definition for @ref SHM_t.ChipId. */
-typedef register_container RegSHMChipId_t {
-    /** @brief 32bit direct register access. */
-    BCM5719_SHM_H_uint32_t r32;
-#ifdef CXX_SIMULATOR
-    /** @brief Register name for use with the simulator. */
-    const char* getName(void) { return "ChipId"; }
-
-    /** @brief Print register value. */
-    void print(void) { r32.print(); }
-
-    RegSHMChipId_t()
-    {
-        /** @brief constructor for @ref SHM_t.ChipId. */
-        r32.setName("ChipId");
-    }
-    RegSHMChipId_t& operator=(const RegSHMChipId_t& other)
-    {
-        r32 = other.r32;
-        return *this;
-    }
-#endif /* CXX_SIMULATOR */
-} RegSHMChipId_t;
+} RegSHMRcpuPrintfBuffer_t;
 
 /** @brief Component definition for @ref SHM. */
 typedef struct SHM_t {
@@ -1781,37 +1681,19 @@ typedef struct SHM_t {
     RegSHMProtMac0Low_t ProtMac0Low;
 
     /** @brief Reserved bytes to pad out data structure. */
-    BCM5719_SHM_H_uint32_t reserved_796[313];
+    BCM5719_SHM_H_uint32_t reserved_796[2];
 
-    /** @brief Set to NCSI_MAGIC ('NCSI') by APE firmware. NOTE: all words in the NCSI section are available in the function 0 SHM area only. */
-    RegSHMNcsiSig_t NcsiSig;
+    /** @brief Index into the printf buffer for last valid byte. */
+    RegSHMRcpuWritePointer_t RcpuWritePointer;
 
-    /** @brief Reserved bytes to pad out data structure. */
-    BCM5719_SHM_H_uint32_t reserved_2052[3];
+    /** @brief Index into the printf buffer for last read byte. */
+    RegSHMRcpuHostReadPointer_t RcpuHostReadPointer;
 
-    /** @brief ASCII string spanning three 32-bit words. Unused trailing bytes   are set to zero. */
-    RegSHMNcsiBuildTime_t NcsiBuildTime;
+    /** @brief Index into the printf buffer for last read byte. */
+    RegSHMRcpuReadPointer_t RcpuReadPointer;
 
-    /** @brief  */
-    RegSHMNcsiBuildTime2_t NcsiBuildTime2;
-
-    /** @brief  */
-    RegSHMNcsiBuildTime3_t NcsiBuildTime3;
-
-    /** @brief ASCII string spanning three 32-bit words. Unused trailing bytes   are set to zero. */
-    RegSHMNcsiBuildDate_t NcsiBuildDate;
-
-    /** @brief  */
-    RegSHMNcsiBuildDate2_t NcsiBuildDate2;
-
-    /** @brief  */
-    RegSHMNcsiBuildDate3_t NcsiBuildDate3;
-
-    /** @brief Reserved bytes to pad out data structure. */
-    BCM5719_SHM_H_uint32_t reserved_2088[26];
-
-    /** @brief The APE code copies the contents of Chip ID to this word */
-    RegSHMChipId_t ChipId;
+    /** @brief Printf buffer from the APE to the Rcpu for NVRAM printout or the host */
+    RegSHMRcpuPrintfBuffer_t RcpuPrintfBuffer[372];
 
 #ifdef CXX_SIMULATOR
     SHM_t()
@@ -1887,26 +1769,17 @@ typedef struct SHM_t {
         }
         ProtMac0High.r32.setComponentOffset(0x314);
         ProtMac0Low.r32.setComponentOffset(0x318);
-        for(int i = 0; i < 313; i++)
+        for(int i = 0; i < 2; i++)
         {
             reserved_796[i].setComponentOffset(0x31c + (i * 4));
         }
-        NcsiSig.r32.setComponentOffset(0x800);
-        for(int i = 0; i < 3; i++)
+        RcpuWritePointer.r32.setComponentOffset(0x324);
+        RcpuHostReadPointer.r32.setComponentOffset(0x328);
+        RcpuReadPointer.r32.setComponentOffset(0x32c);
+        for(int i = 0; i < 372; i++)
         {
-            reserved_2052[i].setComponentOffset(0x804 + (i * 4));
+            RcpuPrintfBuffer[i].r32.setComponentOffset(0x330 + (i * 4));
         }
-        NcsiBuildTime.r32.setComponentOffset(0x810);
-        NcsiBuildTime2.r32.setComponentOffset(0x814);
-        NcsiBuildTime3.r32.setComponentOffset(0x818);
-        NcsiBuildDate.r32.setComponentOffset(0x81c);
-        NcsiBuildDate2.r32.setComponentOffset(0x820);
-        NcsiBuildDate3.r32.setComponentOffset(0x824);
-        for(int i = 0; i < 26; i++)
-        {
-            reserved_2088[i].setComponentOffset(0x828 + (i * 4));
-        }
-        ChipId.r32.setComponentOffset(0x890);
     }
     void print()
     {
@@ -1981,26 +1854,17 @@ typedef struct SHM_t {
         }
         ProtMac0High.print();
         ProtMac0Low.print();
-        for(int i = 0; i < 313; i++)
+        for(int i = 0; i < 2; i++)
         {
             reserved_796[i].print();
         }
-        NcsiSig.print();
-        for(int i = 0; i < 3; i++)
+        RcpuWritePointer.print();
+        RcpuHostReadPointer.print();
+        RcpuReadPointer.print();
+        for(int i = 0; i < 372; i++)
         {
-            reserved_2052[i].print();
+            RcpuPrintfBuffer[i].print();
         }
-        NcsiBuildTime.print();
-        NcsiBuildTime2.print();
-        NcsiBuildTime3.print();
-        NcsiBuildDate.print();
-        NcsiBuildDate2.print();
-        NcsiBuildDate3.print();
-        for(int i = 0; i < 26; i++)
-        {
-            reserved_2088[i].print();
-        }
-        ChipId.print();
     }
     typedef uint32_t (*callback_t)(uint32_t, uint32_t, void*);
     callback_t mIndexReadCallback;
@@ -2029,7 +1893,7 @@ extern volatile SHM_t SHM;
 #undef BITFIELD_END
 
 #ifndef CXX_SIMULATOR
-_Static_assert(sizeof(SHM_t) == 2196, "sizeof(SHM_t) must be 2196");
+_Static_assert(sizeof(SHM_t) == 2304, "sizeof(SHM_t) must be 2304");
 #endif
 
 #endif /* !BCM5719_SHM_H */

--- a/ipxact/SHM.xml
+++ b/ipxact/SHM.xml
@@ -555,65 +555,34 @@
                     <ipxact:volatile>true</ipxact:volatile>
                 </ipxact:register>
                 <ipxact:register>
-                    <ipxact:name>NCSI_SIG</ipxact:name>
-                    <ipxact:description>Set to NCSI_MAGIC ('NCSI') by APE firmware. NOTE: all words in the NCSI section are available in the function 0 SHM area only.</ipxact:description>
-                    <ipxact:addressOffset>0x800</ipxact:addressOffset>
+                    <ipxact:name>RCPU Write Pointer</ipxact:name>
+                    <ipxact:description>Index into the printf buffer for last valid byte.</ipxact:description>
+                    <ipxact:addressOffset>0x324</ipxact:addressOffset>
                     <!-- LINK: registerDefinitionGroup: see 6.11.3, Register definition group -->
                     <ipxact:size>32</ipxact:size>
                     <ipxact:volatile>true</ipxact:volatile>
                 </ipxact:register>
                 <ipxact:register>
-                    <ipxact:name>NCSI_BUILD_TIME</ipxact:name>
-                    <ipxact:description>ASCII string spanning three 32-bit words. Unused trailing bytes   are set to zero.</ipxact:description>
-                    <ipxact:addressOffset>0x810</ipxact:addressOffset>
+                    <ipxact:name>RCPU Host Read Pointer</ipxact:name>
+                    <ipxact:description>Index into the printf buffer for last read byte.</ipxact:description>
+                    <ipxact:addressOffset>0x328</ipxact:addressOffset>
                     <!-- LINK: registerDefinitionGroup: see 6.11.3, Register definition group -->
                     <ipxact:size>32</ipxact:size>
                     <ipxact:volatile>true</ipxact:volatile>
                 </ipxact:register>
                 <ipxact:register>
-                    <ipxact:name>NCSI_BUILD_TIME_2</ipxact:name>
-                    <ipxact:description></ipxact:description>
-                    <ipxact:addressOffset>0x814</ipxact:addressOffset>
+                    <ipxact:name>RCPU Read Pointer</ipxact:name>
+                    <ipxact:description>Index into the printf buffer for last read byte.</ipxact:description>
+                    <ipxact:addressOffset>0x32C</ipxact:addressOffset>
                     <!-- LINK: registerDefinitionGroup: see 6.11.3, Register definition group -->
                     <ipxact:size>32</ipxact:size>
                     <ipxact:volatile>true</ipxact:volatile>
                 </ipxact:register>
                 <ipxact:register>
-                    <ipxact:name>NCSI_BUILD_TIME_3</ipxact:name>
-                    <ipxact:description></ipxact:description>
-                    <ipxact:addressOffset>0x818</ipxact:addressOffset>
-                    <!-- LINK: registerDefinitionGroup: see 6.11.3, Register definition group -->
-                    <ipxact:size>32</ipxact:size>
-                    <ipxact:volatile>true</ipxact:volatile>
-                </ipxact:register>
-                <ipxact:register>
-                    <ipxact:name>NCSI_BUILD_DATE</ipxact:name>
-                    <ipxact:description>ASCII string spanning three 32-bit words. Unused trailing bytes   are set to zero.</ipxact:description>
-                    <ipxact:addressOffset>0x81c</ipxact:addressOffset>
-                    <!-- LINK: registerDefinitionGroup: see 6.11.3, Register definition group -->
-                    <ipxact:size>32</ipxact:size>
-                    <ipxact:volatile>true</ipxact:volatile>
-                </ipxact:register>
-                <ipxact:register>
-                    <ipxact:name>NCSI_BUILD_DATE_2</ipxact:name>
-                    <ipxact:description></ipxact:description>
-                    <ipxact:addressOffset>0x820</ipxact:addressOffset>
-                    <!-- LINK: registerDefinitionGroup: see 6.11.3, Register definition group -->
-                    <ipxact:size>32</ipxact:size>
-                    <ipxact:volatile>true</ipxact:volatile>
-                </ipxact:register>
-                <ipxact:register>
-                    <ipxact:name>NCSI_BUILD_DATE_3</ipxact:name>
-                    <ipxact:description></ipxact:description>
-                    <ipxact:addressOffset>0x824</ipxact:addressOffset>
-                    <!-- LINK: registerDefinitionGroup: see 6.11.3, Register definition group -->
-                    <ipxact:size>32</ipxact:size>
-                    <ipxact:volatile>true</ipxact:volatile>
-                </ipxact:register>
-                <ipxact:register>
-                    <ipxact:name>CHIP_ID</ipxact:name>
-                    <ipxact:description>The APE code copies the contents of Chip ID to this word</ipxact:description>
-                    <ipxact:addressOffset>0x890</ipxact:addressOffset>
+                    <ipxact:name>RCPU Printf Buffer</ipxact:name>
+                    <ipxact:description>Printf buffer from the APE to the Rcpu for NVRAM printout or the host</ipxact:description>
+                    <ipxact:addressOffset>0x330</ipxact:addressOffset>
+                    <ipxact:dim>372</ipxact:dim>
                     <!-- LINK: registerDefinitionGroup: see 6.11.3, Register definition group -->
                     <ipxact:size>32</ipxact:size>
                     <ipxact:volatile>true</ipxact:volatile>

--- a/libs/bcm5719/APE_sym.s
+++ b/libs/bcm5719/APE_sym.s
@@ -10,7 +10,7 @@
 ###
 ################################################################################
 ###
-### @copyright Copyright (c) 2018, Evan Lojewski
+### @copyright Copyright (c) 2020, Evan Lojewski
 ### @cond
 ###
 ### All rights reserved.
@@ -56,7 +56,7 @@
 
 .global SHM
 .equ    SHM, 0x60220000
-.size   SHM, 0x894
+.size   SHM, 0x900
 
 .global SHM_CHANNEL0
 .equ    SHM_CHANNEL0, 0x60220900
@@ -142,20 +142,16 @@
 .equ    FILTERS3, 0xa0078000
 .size   FILTERS3, 0x200
 
-.global DEBUG
-.equ    DEBUG, 0x60221000
-.size   DEBUG, 0x1000
-
 .global SHM1
 .equ    SHM1, 0x60221000
-.size   SHM1, 0x894
+.size   SHM1, 0x900
 
 .global SHM2
 .equ    SHM2, 0x60222000
-.size   SHM2, 0x894
+.size   SHM2, 0x900
 
 .global SHM3
 .equ    SHM3, 0x60223000
-.size   SHM3, 0x894
+.size   SHM3, 0x900
 
 

--- a/libs/bcm5719/bcm5719_sym.s
+++ b/libs/bcm5719/bcm5719_sym.s
@@ -10,7 +10,7 @@
 ###
 ################################################################################
 ###
-### @copyright Copyright (c) 2018, Evan Lojewski
+### @copyright Copyright (c) 2020, Evan Lojewski
 ### @cond
 ###
 ### All rights reserved.
@@ -52,7 +52,7 @@
 
 .global SHM
 .equ    SHM, 0xc0014000
-.size   SHM, 0x894
+.size   SHM, 0x900
 
 .global SHM_CHANNEL0
 .equ    SHM_CHANNEL0, 0xc0014900

--- a/libs/printf/ape_putchar.c
+++ b/libs/printf/ape_putchar.c
@@ -44,26 +44,24 @@
 
 #include <printf.h>
 #include <em100_putchar.h>
-#include <APE_DEBUG.h>
+#include <APE_SHM.h>
 
 void _putchar(char character)
 {
-    uint32_t write_pointer = DEBUG.WritePointer.r32;
+    uint32_t write_pointer = SHM.RcpuWritePointer.r32;
     uint32_t word_pointer = write_pointer / 4;
     uint32_t byte_index = write_pointer % 4;
     uint32_t byte_mask = 0xFF << (byte_index * 8);
 
-    uint32_t new_word = DEBUG.Buffer[word_pointer].r32 & ~byte_mask;
+    uint32_t new_word = SHM.RcpuPrintfBuffer[word_pointer].r32 & ~byte_mask;
     new_word |= character << (byte_index * 8);
-    DEBUG.Buffer[word_pointer].r32 = new_word;
+    SHM.RcpuPrintfBuffer[word_pointer].r32 = new_word;
     write_pointer++;
 
-    if(write_pointer >= sizeof(DEBUG.Buffer))
+    if(write_pointer >= sizeof(SHM.RcpuPrintfBuffer))
     {
         write_pointer = 0;
     }
 
-    DEBUG.WritePointer.r32 = write_pointer;
-
-    em100_putchar(character);
+    SHM.RcpuWritePointer.r32 = write_pointer;
 }

--- a/simulator/bcm5719_SHM.cpp
+++ b/simulator/bcm5719_SHM.cpp
@@ -10,7 +10,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// @copyright Copyright (c) 2018, Evan Lojewski
+/// @copyright Copyright (c) 2020, Evan Lojewski
 /// @cond
 ///
 /// All rights reserved.
@@ -127,21 +127,13 @@ void init_bcm5719_SHM(void)
 
     /** @brief Bitmap for @ref SHM_t.ProtMac0Low. */
 
-    /** @brief Bitmap for @ref SHM_t.NcsiSig. */
+    /** @brief Bitmap for @ref SHM_t.RcpuWritePointer. */
 
-    /** @brief Bitmap for @ref SHM_t.NcsiBuildTime. */
+    /** @brief Bitmap for @ref SHM_t.RcpuHostReadPointer. */
 
-    /** @brief Bitmap for @ref SHM_t.NcsiBuildTime2. */
+    /** @brief Bitmap for @ref SHM_t.RcpuReadPointer. */
 
-    /** @brief Bitmap for @ref SHM_t.NcsiBuildTime3. */
-
-    /** @brief Bitmap for @ref SHM_t.NcsiBuildDate. */
-
-    /** @brief Bitmap for @ref SHM_t.NcsiBuildDate2. */
-
-    /** @brief Bitmap for @ref SHM_t.NcsiBuildDate3. */
-
-    /** @brief Bitmap for @ref SHM_t.ChipId. */
+    /** @brief Bitmap for @ref SHM_t.RcpuPrintfBuffer. */
 
 
 }

--- a/simulator/bcm5719_SHM_sim.cpp
+++ b/simulator/bcm5719_SHM_sim.cpp
@@ -10,7 +10,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// @copyright Copyright (c) 2018, Evan Lojewski
+/// @copyright Copyright (c) 2020, Evan Lojewski
 /// @cond
 ///
 /// All rights reserved.
@@ -277,52 +277,29 @@ void init_bcm5719_SHM_sim(void *base)
     SHM.ProtMac0Low.r32.installReadCallback(read_from_ram, (uint8_t *)base);
     SHM.ProtMac0Low.r32.installWriteCallback(write_to_ram, (uint8_t *)base);
 
-    for(int i = 0; i < 313; i++)
+    for(int i = 0; i < 2; i++)
     {
         SHM.reserved_796[i].installReadCallback(read_from_ram, (uint8_t *)base);
         SHM.reserved_796[i].installWriteCallback(write_to_ram, (uint8_t *)base);
     }
-    /** @brief Bitmap for @ref SHM_t.NcsiSig. */
-    SHM.NcsiSig.r32.installReadCallback(read_from_ram, (uint8_t *)base);
-    SHM.NcsiSig.r32.installWriteCallback(write_to_ram, (uint8_t *)base);
+    /** @brief Bitmap for @ref SHM_t.RcpuWritePointer. */
+    SHM.RcpuWritePointer.r32.installReadCallback(read_from_ram, (uint8_t *)base);
+    SHM.RcpuWritePointer.r32.installWriteCallback(write_to_ram, (uint8_t *)base);
 
-    for(int i = 0; i < 3; i++)
+    /** @brief Bitmap for @ref SHM_t.RcpuHostReadPointer. */
+    SHM.RcpuHostReadPointer.r32.installReadCallback(read_from_ram, (uint8_t *)base);
+    SHM.RcpuHostReadPointer.r32.installWriteCallback(write_to_ram, (uint8_t *)base);
+
+    /** @brief Bitmap for @ref SHM_t.RcpuReadPointer. */
+    SHM.RcpuReadPointer.r32.installReadCallback(read_from_ram, (uint8_t *)base);
+    SHM.RcpuReadPointer.r32.installWriteCallback(write_to_ram, (uint8_t *)base);
+
+    /** @brief Bitmap for @ref SHM_t.RcpuPrintfBuffer. */
+    for(int i = 0; i < 372; i++)
     {
-        SHM.reserved_2052[i].installReadCallback(read_from_ram, (uint8_t *)base);
-        SHM.reserved_2052[i].installWriteCallback(write_to_ram, (uint8_t *)base);
+        SHM.RcpuPrintfBuffer[i].r32.installReadCallback(read_from_ram, (uint8_t *)base);
+        SHM.RcpuPrintfBuffer[i].r32.installWriteCallback(write_to_ram, (uint8_t *)base);
     }
-    /** @brief Bitmap for @ref SHM_t.NcsiBuildTime. */
-    SHM.NcsiBuildTime.r32.installReadCallback(read_from_ram, (uint8_t *)base);
-    SHM.NcsiBuildTime.r32.installWriteCallback(write_to_ram, (uint8_t *)base);
-
-    /** @brief Bitmap for @ref SHM_t.NcsiBuildTime2. */
-    SHM.NcsiBuildTime2.r32.installReadCallback(read_from_ram, (uint8_t *)base);
-    SHM.NcsiBuildTime2.r32.installWriteCallback(write_to_ram, (uint8_t *)base);
-
-    /** @brief Bitmap for @ref SHM_t.NcsiBuildTime3. */
-    SHM.NcsiBuildTime3.r32.installReadCallback(read_from_ram, (uint8_t *)base);
-    SHM.NcsiBuildTime3.r32.installWriteCallback(write_to_ram, (uint8_t *)base);
-
-    /** @brief Bitmap for @ref SHM_t.NcsiBuildDate. */
-    SHM.NcsiBuildDate.r32.installReadCallback(read_from_ram, (uint8_t *)base);
-    SHM.NcsiBuildDate.r32.installWriteCallback(write_to_ram, (uint8_t *)base);
-
-    /** @brief Bitmap for @ref SHM_t.NcsiBuildDate2. */
-    SHM.NcsiBuildDate2.r32.installReadCallback(read_from_ram, (uint8_t *)base);
-    SHM.NcsiBuildDate2.r32.installWriteCallback(write_to_ram, (uint8_t *)base);
-
-    /** @brief Bitmap for @ref SHM_t.NcsiBuildDate3. */
-    SHM.NcsiBuildDate3.r32.installReadCallback(read_from_ram, (uint8_t *)base);
-    SHM.NcsiBuildDate3.r32.installWriteCallback(write_to_ram, (uint8_t *)base);
-
-    for(int i = 0; i < 26; i++)
-    {
-        SHM.reserved_2088[i].installReadCallback(read_from_ram, (uint8_t *)base);
-        SHM.reserved_2088[i].installWriteCallback(write_to_ram, (uint8_t *)base);
-    }
-    /** @brief Bitmap for @ref SHM_t.ChipId. */
-    SHM.ChipId.r32.installReadCallback(read_from_ram, (uint8_t *)base);
-    SHM.ChipId.r32.installWriteCallback(write_to_ram, (uint8_t *)base);
 
 
 }

--- a/utils/bcmregtool/main.cpp
+++ b/utils/bcmregtool/main.cpp
@@ -943,9 +943,6 @@ int main(int argc, char const *argv[])
         exit(0);
     }
 
-
-    printf("APEChipId: %x\n", (uint32_t)SHM.ChipId.r32);
-
     printf("EmacMode.PortMode: %0x\n", (uint32_t)DEVICE.EmacMode.bits.PortMode);
     printf("RxRiscMode: %0x\n", (uint32_t)DEVICE.RxRiscMode.r32);
 


### PR DESCRIPTION
…n when the rx cpu is restarted.

Rather than print directly, the APE now using the host debug console only for printf.
The RX cpu (function 0 only) uses the debug console and forwards it over SPI when new data is available.