### PR TITLE
ncsi: Don't report an error when clearing the initial state of nonexi…

### DIFF
--- a/libs/NCSI/ncsi.c
+++ b/libs/NCSI/ncsi.c
@@ -285,11 +285,15 @@ static void clearInitialStateHandler(NetworkFrame_t *frame)
 {
     int ch = frame->controlPacket.ChannelID & CHANNEL_ID_MASK;
 
-    gPackageState.port[ch]->shm_channel->NcsiChannelInfo.bits.Ready = true;
-    debug("Clear initial state: channel %x\n", ch);
+    // Only send a response if this channel exists.
+    if (ch < NUM_CHANNELS)
+    {
+        gPackageState.port[ch]->shm_channel->NcsiChannelInfo.bits.Ready = true;
+        debug("Clear initial state: channel %x\n", ch);
 
-    sendNCSIResponse(frame->controlPacket.InstanceID, frame->controlPacket.ChannelID, frame->controlPacket.ControlPacketType,
-                     NCSI_RESPONSE_CODE_COMMAND_COMPLETE, NCSI_REASON_CODE_NONE);
+        sendNCSIResponse(frame->controlPacket.InstanceID, frame->controlPacket.ChannelID, frame->controlPacket.ControlPacketType,
+                         NCSI_RESPONSE_CODE_COMMAND_COMPLETE, NCSI_REASON_CODE_NONE);
+    }
 }
 
 static void selectPackageHandler(NetworkFrame_t *frame)
@@ -617,7 +621,7 @@ void handleNCSIFrame(NetworkFrame_t *frame)
                              NCSI_RESPONSE_CODE_COMMAND_FAILED, NCSI_REASON_CODE_INVALID_PAYLOAD_LENGTH);
         }
         else if ((handler->packageCommand && ch == CHANNEL_ID_PACKAGE) || // Package commands are always accepted.
-                 (handler->ignoreInit && ch < NUM_CHANNELS))
+                 (handler->ignoreInit))
         {
             // Package command. Must handle.
             debug("[%x] packageCommand/ignore init channel: %d\n", command, ch);


### PR DESCRIPTION
…stent channels.

The NCSI specification implies that when a channel does not exist, no response is given.
This behavior is consistent with the proprietary firmware.

When a response is given, the linux kernel spews (~30 times) "NCSI: 'bad' packet
ignored for type 0x80" on an invalid response. Disable the response to silence
these messages and make the behavior match the proprietary firmware.