### PR TITLE
bcmflash: Read the entire flash contents

### DIFF
--- a/utils/bcmflash/main.cpp
+++ b/utils/bcmflash/main.cpp
@@ -88,7 +88,7 @@ bool save_to_file(const char *filename, void *buffer, size_t size)
     }
 }
 
-#define NVRAM_SIZE (1024u * 256u) /* 256KB */
+#define NVRAM_SIZE (2048u * 256u) /* 256KB */
 int main(int argc, char const *argv[])
 {
     bool extract = false;

--- a/utils/bcmflash/main.cpp
+++ b/utils/bcmflash/main.cpp
@@ -88,7 +88,7 @@ bool save_to_file(const char *filename, void *buffer, size_t size)
     }
 }
 
-#define NVRAM_SIZE (2048u * 256u) /* 256KB */
+#define NVRAM_SIZE (2048u * 256u) /* 512KB */
 int main(int argc, char const *argv[])
 {
     bool extract = false;


### PR DESCRIPTION
The AT45DB041D is used on the Dell KH08P I have here, which is configured as
2048 pages of 256 bytes. The standalone PCI card also contains large option ROM
modules and this means only reading the first 0x40000 bytes misses some of the
code directory sections.