### PR TITLE
stage1: Add a locatable version string.

### DIFF
--- a/stage1/CMakeLists.txt
+++ b/stage1/CMakeLists.txt
@@ -52,6 +52,10 @@ mips_add_executable(${PROJECT_NAME}
             main.c
             crt.s)
 mips_linker_script(${PROJECT_NAME} ${LINKER_SCRIPT})
+target_link_libraries(${PROJECT_NAME}
+    --defsym=VERSION_MAJOR=${VERSION_MAJOR}
+    --defsym=VERSION_MINOR=${VERSION_MINOR}
+    --defsym=VERSION_PATCH=${VERSION_PATCH})
 
 target_link_libraries(${PROJECT_NAME} NVRam-mips MII-mips APE-mips printf-mips)
 target_link_libraries(${PROJECT_NAME} bcm5719)

--- a/stage1/crt.s
+++ b/stage1/crt.s
@@ -1,9 +1,60 @@
-
+////////////////////////////////////////////////////////////////////////////////
+///
+/// @file       stage1/crt.s
+///
+/// @project
+///
+/// @brief      stage1 startup code
+///
+////////////////////////////////////////////////////////////////////////////////
+///
+////////////////////////////////////////////////////////////////////////////////
+///
+/// @copyright Copyright (c) 2018-2020, Evan Lojewski
+/// @cond
+///
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without
+/// modification, are permitted provided that the following conditions are met:
+/// 1. Redistributions of source code must retain the above copyright notice,
+/// this list of conditions and the following disclaimer.
+/// 2. Redistributions in binary form must reproduce the above copyright notice,
+/// this list of conditions and the following disclaimer in the documentation
+/// and/or other materials provided with the distribution.
+/// 3. Neither the name of the copyright holder nor the
+/// names of its contributors may be used to endorse or promote products
+/// derived from this software without specific prior written permission.
+///
+////////////////////////////////////////////////////////////////////////////////
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+/// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+/// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+/// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+/// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+/// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+/// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+/// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+/// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// @endcond
+////////////////////////////////////////////////////////////////////////////////
 
 .section .init
 .global __start
 .align 4
 __start:
+    j       _main
+    // NOP is automatically added by llvm
+
+_version_ptr:
+    .word gStage1Version
+_version_data:
+    .word (VERSION_MAJOR << 24) | (VERSION_MINOR << 16) | VERSION_PATCH
+
+_main:
     la      $sp, _estack
     j       main
 .size __start, . - __start

--- a/stage1/main.c
+++ b/stage1/main.c
@@ -66,6 +66,8 @@
 #include <bcm5719_GEN.h>
 #include <bcm5719_SHM.h>
 
+const char gStage1Version[] = "stage1-" STRINGIFY(VERSION_MAJOR) "." STRINGIFY(VERSION_MINOR) "." STRINGIFY(VERSION_PATCH);
+
 NVRAMContents_t gNVMContents;
 
 void __attribute__((noinline)) reportStatus(uint32_t code, uint8_t step)
@@ -139,7 +141,9 @@ int main()
 
     if (0 == DEVICE.Status.bits.FunctionNumber)
     {
-        em100_puts("RX Firmware v" STRINGIFY(VERSION_MAJOR) "." STRINGIFY(VERSION_MINOR) "." STRINGIFY(VERSION_PATCH) "\n");
+        em100_puts("RX Firmware ");
+        em100_puts(gStage1Version);
+        em100_puts("\n");
     }
 
 #if !CXX_SIMULATOR


### PR DESCRIPTION
Similar to the proprietary firmware, add a version string pointer
8 bytes into the firmware image.

This closes GH-114