### PR TITLE
ape: Remove a couple of posisble infinte loops that can happen with misbehaving hardware.

### DIFF
--- a/ape/include/ape_main.h
+++ b/ape/include/ape_main.h
@@ -45,6 +45,8 @@
 #ifndef APE_H
 #define APE_H
 
-void initRMU(void);
+void RMU_init(void);
+
+void RMU_resetBadPacket(void);
 
 #endif /* APE_H */


### PR DESCRIPTION
- Stop waiting for the RX CPUs to reset after 1 second of waiting.
- Stop waiting for the RMU to reset after 100ms.

Closes GH-96.