### PR TITLE
bcmflash: Fix default vendor and device ids.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The current version of the code is functional and is able to handle network traf
 Blackbird and Talos II users may install this firmware using [fwupd](https://fwupd.org/), either via the Linux Vendor Firmware Service, or manually using `fwupdtool` and a [release archive](https://github.com/meklort/bcm5719-fw/releases). Other BCM5719 devices may not be thoroughly tested, or tested at all; should you wish to proceed, it is encouraged to download or [build](#building) the firmware and refer to instructions in [Development](#development), especially the section on [testing APE firmware](#testing-ape-firmware).
 
 ## Installing using LVFS
-This project provides firmware releases on LVFS that can be installed using fwupd 1.5.0 or later.
+This project provides firmware releases on LVFS that can be installed using fwupd 1.5.2 or later.
 The firmware can be selected for install by following the prompts using the `switch-branch` command in `fwupdmgr`:
 ```bash
 sudo fwupdmgr switch-branch
@@ -40,7 +40,7 @@ This will flash the latest firmware from LVFS onto the network card and will sav
 Once switched, future releases will be installed using the standard update mechanism in fwupd.
 
 ## Installing using fwupdtool
-Alternatively to using LVFS, the fwupd cab files in the release package can be manually flashed with `fwupdtool` 1.5.0 or later.
+Alternatively to using LVFS, the fwupd cab files in the release package can be manually flashed with `fwupdtool` 1.5.2 or later.
 
 For **Talos II**:
 ```bash

--- a/fwupd/metainfo.xml.in
+++ b/fwupd/metainfo.xml.in
@@ -36,8 +36,8 @@
     </categories>
 
     <requires>
-        <!-- Restrict to fwupd >= 1.5.0 -->
-        <id compare="ge" version="1.5.0">org.freedesktop.fwupd</id>
+        <!-- Restrict to fwupd >= 1.5.2 -->
+        <id compare="ge" version="1.5.2">org.freedesktop.fwupd</id>
         <client>switch-branch</client>
         @HARDWARE_FILTER@
     </requires>

--- a/include/bcm5719_eeprom.h
+++ b/include/bcm5719_eeprom.h
@@ -168,75 +168,39 @@ typedef struct {
 
     uint8_t     mfrData[4];
 
-#ifdef __LITTLE_ENDIAN__
     uint16_t    func1PXEVLAN;
     uint16_t    func0PXEVLAN;
-#else
-    uint16_t    func0PXEVLAN;
-    uint16_t    func1PXEVLAN;
-#endif
 
-#ifdef __LITTLE_ENDIAN__
-    uint16_t    vendorID;           /*< PCI Vendor ID. */
-    uint16_t    deviceID;           /*< PCI Device ID. */
-#else
     uint16_t    deviceID;           /*< PCI Device ID. */
     uint16_t    vendorID;           /*< PCI Vendor ID. */
-#endif
 
-#ifdef __LITTLE_ENDIAN__
-    uint16_t    subsystemVendorID;  /*< PCI Subsystem Vendor ID. */
-    uint16_t    subsystemDeviceID;  /*< PCI Subsystem Device ID. */
-#else
     uint16_t    subsystemDeviceID;  /*< PCI Subsystem Device ID. */
     uint16_t    subsystemVendorID;  /*< PCI Subsystem Vendor ID. */
-#endif
 
-#ifdef __LITTLE_ENDIAN__
     uint16_t    cpuClock;           /*< 66MHz, Legacy */
 
     uint8_t     SMBusAddr;
     uint8_t     SMBusAddrBMC;
-#else
-    uint8_t     SMBusAddrBMC;
-    uint8_t     SMBusAddr;
-
-    uint16_t    cpuClock;           /*< 66MHz, Legacy */
-#endif
 
     uint32_t    macAddr0Backup[2];
     uint32_t    macAddr1Backup[2];
 
     union {
         struct {
-#ifdef __LITTLE_ENDIAN__
             uint8_t     powerDissipatedD3;  /*< Power dissipated in the D3 state. Note: The data scale is hard coded at 0.1. */
             uint8_t     powerDissipatedD2;  /*< Power dissipated in the D2 state. The NetXtreme II family does not support the D2 state. */
             uint8_t     powerDissipatedD1;  /*< Power dissipated in the D1 state. The NetXtreme II family does not support the D1 state. */
             uint8_t     powerDissipatedD0;  /*< Power dissipated in the D0 state. Note: The data scale is hard coded at 0.1. */
-#else
-            uint8_t     powerDissipatedD0;  /*< Power dissipated in the D0 state. Note: The data scale is hard coded at 0.1. */
-            uint8_t     powerDissipatedD1;  /*< Power dissipated in the D1 state. The NetXtreme II family does not support the D1 state. */
-            uint8_t     powerDissipatedD2;  /*< Power dissipated in the D2 state. The NetXtreme II family does not support the D2 state. */
-            uint8_t     powerDissipatedD3;  /*< Power dissipated in the D3 state. Note: The data scale is hard coded at 0.1. */
-#endif
         };
         uint32_t     powerDissipated;
     };
 
     union {
         struct {
-#ifdef __LITTLE_ENDIAN__
             uint8_t     powerConsumedD3;    /*< Power consumed in the D3 state. Note: The data scale is hard coded at 0.1. */
             uint8_t     powerConsumedD2;    /*< Power consumed in the D2 state. The NetXtreme II family does not support the D2 state. */
             uint8_t     powerConsumedD1;    /*< Power consumed in the D1 state. The NetXtreme II family does not support the D1 state. */
             uint8_t     powerConsumedD0;    /*< Power consumed in the D0 state. Note: The data scale is hard coded at 0.1. */
-#else
-            uint8_t     powerConsumedD0;    /*< Power consumed in the D0 state. Note: The data scale is hard coded at 0.1. */
-            uint8_t     powerConsumedD1;    /*< Power consumed in the D1 state. The NetXtreme II family does not support the D1 state. */
-            uint8_t     powerConsumedD2;    /*< Power consumed in the D2 state. The NetXtreme II family does not support the D2 state. */
-            uint8_t     powerConsumedD3;    /*< Power consumed in the D3 state. Note: The data scale is hard coded at 0.1. */
-#endif
         };
         uint32_t     powerConsumed;
     };
@@ -253,33 +217,18 @@ typedef struct {
     uint32_t    powerBudget0;
     uint32_t    powerBudget1;
     uint32_t    serworksUse;
-#ifdef __LITTLE_ENDIAN__
     uint16_t    func1SERDESOverride;
     uint16_t    func0SERDESOverride;
-#else
-    uint16_t    func0SERDESOverride;
-    uint16_t    func1SERDESOverride;
-#endif
-#ifdef __LITTLE_ENDIAN__
     uint16_t    tpmNVMSize;
     uint16_t    macNVMSize;
-#else
-    uint16_t    macNVMSize;
-    uint16_t    tpmNVMSize;
-#endif
     uint32_t    powerBudget2;
     uint32_t    powerBudget3;
     uint32_t    mfrCRC;
 } NVRAMInfo_t;
 
 typedef struct {
-#ifdef __LITTLE_ENDIAN__
     uint16_t    mfr2Unk;                //   [200] 00 00          -- Unknown, probably unused.
     uint16_t    mfr2Len;                //   [202] 00 8C          -- Length of manufacturing section 2.
-#else
-    uint16_t    mfr2Len;                //   [202] 00 8C          -- Length of manufacturing section 2.
-    uint16_t    mfr2Unk;                //   [200] 00 00          -- Unknown, probably unused.
-#endif
     uint32_t    UNKNOWN0;               //   [204] 00 00 00 00    -- Could be reserved.
 
     uint32_t    macAddr2[2];            //1  [208] Upper 16 bits are zero/unused.
@@ -291,42 +240,17 @@ typedef struct {
     uint32_t    UNKNOWN4;               //   [220] 0
     uint32_t    UNKNOWN5;               //   [224] 0
 
-#ifdef __LITTLE_ENDIAN__
     uint16_t    func3PXEVLAN;
     uint16_t    func2PXEVLAN;
-#else
-    uint16_t    func2PXEVLAN;
-    uint16_t    func3PXEVLAN;
-#endif
 
-#ifdef __LITTLE_ENDIAN__
-    uint16_t    pciSubsystemF0GPHY;
-    uint16_t    pciSubsystemF1GPHY;
-#else
     uint16_t    pciSubsystemF1GPHY;
     uint16_t    pciSubsystemF0GPHY;
-#endif
-#ifdef __LITTLE_ENDIAN__
-    uint16_t    pciSubsystemF2GPHY;
-    uint16_t    pciSubsystemF3GPHY;
-#else
     uint16_t    pciSubsystemF3GPHY;
     uint16_t    pciSubsystemF2GPHY;
-#endif
-#ifdef __LITTLE_ENDIAN__
-    uint16_t    pciSubsystemF0SERDES;
-    uint16_t    pciSubsystemF1SERDES;
-#else
     uint16_t    pciSubsystemF1SERDES;
     uint16_t    pciSubsystemF0SERDES;
-#endif
-#ifdef __LITTLE_ENDIAN__
-    uint16_t    pciSubsystemF2SERDES;
-    uint16_t    pciSubsystemF3SERDES;
-#else
     uint16_t    pciSubsystemF3SERDES;
     uint16_t    pciSubsystemF2SERDES;
-#endif
 
     uint32_t    UNKNOWN7;               //   [23C] 0
     uint32_t    UNKNOWN8;               //   [240] 0

--- a/utils/bcmflash/nvm_blackbird.c
+++ b/utils/bcmflash/nvm_blackbird.c
@@ -73,14 +73,14 @@ NVRAMInfo2_t gBlackbirdNVRAMInfo2 = {
     .func3PXEVLAN = htobe16(0),
     .func2PXEVLAN = htobe16(0),
 
-    .pciSubsystemF0GPHY = htobe16(0x1981),
     .pciSubsystemF1GPHY = htobe16(0x1981),
-    .pciSubsystemF2GPHY = htobe16(0x1981),
+    .pciSubsystemF0GPHY = htobe16(0x1981),
     .pciSubsystemF3GPHY = htobe16(0x1981),
-    .pciSubsystemF0SERDES = htobe16(0x1657),
+    .pciSubsystemF2GPHY = htobe16(0x1981),
     .pciSubsystemF1SERDES = htobe16(0x1657),
-    .pciSubsystemF2SERDES = htobe16(0x1657),
+    .pciSubsystemF0SERDES = htobe16(0x1657),
     .pciSubsystemF3SERDES = htobe16(0x1657),
+    .pciSubsystemF2SERDES = htobe16(0x1657),
 
     .UNKNOWN7 = 0,                          //   [23C] 0
     .UNKNOWN8 = 0,                          //   [240] 0
@@ -113,10 +113,10 @@ NVRAMInfo_t gBlackbirdNVRAMInfo = {
     .mfrData = { 0 },
     .func1PXEVLAN = 0,
     .func0PXEVLAN = 0,
-    .vendorID = htobe16(0x1657),          /*< PCI Vendor ID. */
-    .deviceID = htobe16(0x14E4),          /*< PCI Device ID. */
-    .subsystemVendorID = htobe16(0x1657), /*< PCI Subsystem Vendor ID. */
-    .subsystemDeviceID = htobe16(0x14E4), /*< PCI Subsystem Device ID. */
+    .deviceID = htobe16(0x1657),          /*< PCI Device ID. */
+    .vendorID = htobe16(0x14E4),          /*< PCI Vendor ID. */
+    .subsystemDeviceID = htobe16(0x1657), /*< PCI Subsystem Device ID. */
+    .subsystemVendorID = htobe16(0x14E4), /*< PCI Subsystem Vendor ID. */
 
     .cpuClock = htobe16(66), /*< 66MHz, Legacy */
 

--- a/utils/bcmflash/nvm_kh08p.c
+++ b/utils/bcmflash/nvm_kh08p.c
@@ -73,14 +73,14 @@ NVRAMInfo2_t gKH08PNVRAMInfo2 = {
     .func3PXEVLAN = htobe16(1),
     .func2PXEVLAN = htobe16(1),
 
-    .pciSubsystemF0GPHY = htobe16(0x1904),
     .pciSubsystemF1GPHY = htobe16(0x1904),
-    .pciSubsystemF2GPHY = htobe16(0x1904),
+    .pciSubsystemF0GPHY = htobe16(0x1904),
     .pciSubsystemF3GPHY = htobe16(0x1904),
-    .pciSubsystemF0SERDES = htobe16(0x1657),
+    .pciSubsystemF2GPHY = htobe16(0x1904),
     .pciSubsystemF1SERDES = htobe16(0x1657),
-    .pciSubsystemF2SERDES = htobe16(0x1657),
+    .pciSubsystemF0SERDES = htobe16(0x1657),
     .pciSubsystemF3SERDES = htobe16(0x1657),
+    .pciSubsystemF2SERDES = htobe16(0x1657),
 
     .UNKNOWN7 = 0,                          //   [23C] 0
     .UNKNOWN8 = 0,                          //   [240] 0
@@ -113,10 +113,10 @@ NVRAMInfo_t gKH08PNVRAMInfo = {
     .mfrData = { 0 },
     .func1PXEVLAN = htobe16(1),
     .func0PXEVLAN = htobe16(1),
-    .vendorID = htobe16(0x1657),          /*< PCI Vendor ID. */
-    .deviceID = htobe16(0x14E4),          /*< PCI Device ID. */
-    .subsystemVendorID = htobe16(0x1657), /*< PCI Subsystem Vendor ID. */
-    .subsystemDeviceID = htobe16(0x14E4), /*< PCI Subsystem Device ID. */
+    .deviceID = htobe16(0x1657),          /*< PCI Device ID. */
+    .vendorID = htobe16(0x14E4),          /*< PCI Vendor ID. */
+    .subsystemDeviceID = htobe16(0x1657), /*< PCI Subsystem Device ID. */
+    .subsystemVendorID = htobe16(0x14E4), /*< PCI Subsystem Vendor ID. */
 
     .cpuClock = htobe16(66), /*< 66MHz, Legacy */
 

--- a/utils/bcmflash/nvm_talos2.c
+++ b/utils/bcmflash/nvm_talos2.c
@@ -73,14 +73,14 @@ NVRAMInfo2_t gTalosIINVRAMInfo2 = {
     .func3PXEVLAN = htobe16(0),
     .func2PXEVLAN = htobe16(0),
 
-    .pciSubsystemF0GPHY = htobe16(0x1981),
     .pciSubsystemF1GPHY = htobe16(0x1981),
-    .pciSubsystemF2GPHY = htobe16(0x1981),
+    .pciSubsystemF0GPHY = htobe16(0x1981),
     .pciSubsystemF3GPHY = htobe16(0x1981),
-    .pciSubsystemF0SERDES = htobe16(0x1657),
+    .pciSubsystemF2GPHY = htobe16(0x1981),
     .pciSubsystemF1SERDES = htobe16(0x1657),
-    .pciSubsystemF2SERDES = htobe16(0x1657),
+    .pciSubsystemF0SERDES = htobe16(0x1657),
     .pciSubsystemF3SERDES = htobe16(0x1657),
+    .pciSubsystemF2SERDES = htobe16(0x1657),
 
     .UNKNOWN7 = 0,                          //   [23C] 0
     .UNKNOWN8 = 0,                          //   [240] 0
@@ -113,10 +113,10 @@ NVRAMInfo_t gTalosIINVRAMInfo = {
     .mfrData = { 0 },
     .func1PXEVLAN = 0,
     .func0PXEVLAN = 0,
-    .vendorID = htobe16(0x1657),          /*< PCI Vendor ID. */
-    .deviceID = htobe16(0x14E4),          /*< PCI Device ID. */
-    .subsystemVendorID = htobe16(0x1657), /*< PCI Subsystem Vendor ID. */
-    .subsystemDeviceID = htobe16(0x14E4), /*< PCI Subsystem Device ID. */
+    .deviceID = htobe16(0x1657),          /*< PCI Device ID. */
+    .vendorID = htobe16(0x14E4),          /*< PCI Vendor ID. */
+    .subsystemDeviceID = htobe16(0x1657), /*< PCI Subsystem Device ID. */
+    .subsystemVendorID = htobe16(0x14E4), /*< PCI Subsystem Vendor ID. */
 
     .cpuClock = htobe16(66), /*< 66MHz, Legacy */
 


### PR DESCRIPTION
- This also fixes mistaken endianness swapping in the eeprom header.