### PR TITLE
lvfs: Clarify target hardware.

### DIFF
--- a/fwupd/metainfo.xml.in
+++ b/fwupd/metainfo.xml.in
@@ -3,6 +3,7 @@
 <component type="firmware">
     <id>@APP_STREAM_PREFIX@.@TARGET_ID@</id>
     <name>BCM5719</name>
+    <name_variant_suffix>@TARGET_NAME@</name_variant_suffix>
     <summary>Firmware for the @TARGET_NAME@ BCM5719 NIC</summary>
     <branch>oss-firmware</branch>
     <description>


### PR DESCRIPTION
Add the name_variant_suffix to clarify the target hardware for a given cab file.