### PR TITLE
ape: Reset the network interface any time the APE mode is incorrect.

### DIFF
--- a/ape/main.c
+++ b/ape/main.c
@@ -327,6 +327,16 @@ void __attribute__((noreturn)) loaderLoop(void)
                 }
             }
         }
+        else if (!Network_checkEnableState(gPort))
+        {
+            printf("APE mode change, resetting.\n");
+            wait_for_all_rx();
+            RMU_init();
+            NCSI_reload(ALWAYS_RESET);
+
+            // Update host state to make sure we don't reset twice if it's changed.
+            host_state = SHM.HostDriverState.bits.State;
+        }
 
         Network_checkPortState(gPort);
     }

--- a/libs/Network/include/Network.h
+++ b/libs/Network/include/Network.h
@@ -111,6 +111,7 @@ void Network_resetRX(NetworkPort_t *port, reload_type_t reset_phy);
 
 void Network_checkPortState(NetworkPort_t *port);
 bool Network_updatePortState(NetworkPort_t *port);
+bool Network_checkEnableState(NetworkPort_t *port);
 
 bool Network_isLinkUp(NetworkPort_t *port);
 void Network_resetLink(NetworkPort_t *port);

--- a/libs/Network/ports.c
+++ b/libs/Network/ports.c
@@ -846,6 +846,23 @@ void Network_resetRX(NetworkPort_t *port, reload_type_t reset_phy)
     }
 }
 
+bool Network_checkEnableState(NetworkPort_t *port)
+{
+    // Ensure APE mode is set properly
+    if ((APE.Mode.r32 & port->APEModeEnable.r32) != port->APEModeEnable.r32)
+    {
+        return false;
+    }
+
+    // Ensure APE mode2 is set properly
+    if ((APE.Mode2.r32 & port->APEMode2Enable.r32) != port->APEMode2Enable.r32)
+    {
+        return false;
+    }
+
+    return true;
+}
+
 void Network_InitPort(NetworkPort_t *port, reload_type_t reset_phy)
 {
     RegMIIStatus_t stat;


### PR DESCRIPTION
In certain situations, such as a driver unload, the APE mode can be reset.
This adds APE.mode to the current state change check to enable early recovery
from events such as a driver unload.
