### PR TITLE
Revert "build: Enable builds under LLVM 11. (#172)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This repository depends on a number of external tools
 Due to limitations in the MIPS CPU, this firmware requires a custom compiler to function properly.
 The custom compiler can be built using the following steps:
 ```bash
-git clone https://github.com/meklort/llvm-project.git -b meklort-11.0.0
+git clone https://github.com/meklort/llvm-project.git -b meklort-10.0.1
 cd llvm-project
 mkdir build
 cd build

--- a/ape/ape.ld
+++ b/ape/ape.ld
@@ -49,7 +49,7 @@ SECTIONS
     .text 0x00100000 : ALIGN(4) SUBALIGN(4)
     {
         KEEP(*(.init))
-        *(.text*)
+        *(.text)
     }
 
 
@@ -86,3 +86,4 @@ SECTIONS
         *(.pdr)
     }
 }
+

--- a/libs/MII/include/MII.h
+++ b/libs/MII/include/MII.h
@@ -55,9 +55,9 @@
 
 #ifdef CXX_SIMULATOR
 #define volatile
-typedef uintptr_t   mii_reg_t;
+typedef uint64_t    mii_reg_t;
 #else
-typedef uint32_t    mii_reg_t;
+typedef uint16_t    mii_reg_t;
 #endif
 
 /**

--- a/libs/MII/mii.c
+++ b/libs/MII/mii.c
@@ -159,7 +159,7 @@ static int32_t MII_readShadowRegister18(volatile DEVICE_t *device, uint8_t phy, 
     // phy_write(0x18, 0x1007); //switch to shadow 0x1
     // valu = phy_read(0x18);
 
-    uint16_t shadow_reg = (reg & 0xFFFF) >> 8;
+    uint16_t shadow_reg = reg >> 8;
     RegMIIMiscellaneousControl_t shadow_select;
     shadow_select.r16 = 0;
     shadow_select.bits.ShadowRegisterReadSelector = shadow_reg;
@@ -184,7 +184,7 @@ static int32_t MII_readShadowRegister1C(volatile DEVICE_t *device, uint8_t phy, 
     // value = phy_read(0x1C);
     // return value;
 
-    uint16_t shadow_reg = (reg & 0xFFFF) >> 8;
+    uint16_t shadow_reg = reg >> 8;
     RegMIICabletronLed_t shadow_select;
     shadow_select.r16 = 0;
     shadow_select.bits.ShadowRegisterSelector = shadow_reg;
@@ -227,7 +227,7 @@ static bool MII_writeShadowRegister18(volatile DEVICE_t *device, uint8_t phy, mi
     // phy_write(0x18, 0x2007); //switch to shadow 0x2
     // phy_write(0x18, wdata | 0x2 );
 
-    uint16_t shadow_reg = (reg & 0xFFFF) >> 8;
+    uint16_t shadow_reg = reg >> 8;
     RegMIIMiscellaneousControl_t shadow_select;
     shadow_select.r16 = 0;
     shadow_select.bits.ShadowRegisterReadSelector = shadow_reg;
@@ -253,7 +253,7 @@ static bool MII_writeShadowRegister1C(volatile DEVICE_t *device, uint8_t phy, mi
     // phy_write(0x1C, 0x0800); //switch to shadow 0x2
     // phy_write(0x1C, wdata | 0x8800 );
 
-    uint16_t shadow_reg = (reg & 0xFFFF) >> 8;
+    uint16_t shadow_reg = reg >> 8;
     RegMIICabletronLed_t shadow_select;
     shadow_select.r16 = 0;
     shadow_select.bits.ShadowRegisterSelector = shadow_reg;

--- a/utils/bcmregtool/apeloader/ape.ld
+++ b/utils/bcmregtool/apeloader/ape.ld
@@ -49,7 +49,7 @@ SECTIONS
     .text 0x00100000 : ALIGN(4) SUBALIGN(4)
     {
         KEEP(*(.init))
-        *(.text*)
+        *(.text)
     }
 
 
@@ -86,3 +86,4 @@ SECTIONS
         *(.pdr)
     }
 }
+


### PR DESCRIPTION
This reverts commit 5520cf3dff14b3805fafafbfc05853a03aeafcfc.