### PR TITLE
ape: Fix NVIC access.

### DIFF
--- a/include/APE_NVIC.h
+++ b/include/APE_NVIC.h
@@ -78,7 +78,7 @@ typedef uint32_t APE_NVIC_H_uint32_t;
 #define BITFIELD_END(__type__, __name__) } __name__;
 #endif /* !CXX_SIMULATOR */
 
-#define REG_NVIC_BASE ((volatile void*)0x380038000) /* Nested Vectored Interrupt Controller */
+#define REG_NVIC_BASE ((volatile void*)0xe000e000) /* Nested Vectored Interrupt Controller */
 #define REG_NVIC_SIZE (sizeof(NVIC_t))
 
 #define REG_NVIC_INTERRUPT_CONTROL_TYPE ((volatile APE_NVIC_H_uint32_t*)0xe000e004) /* Read the Interrupt Controller Type Register to see the number of interrupt lines that the NVIC supports. */
@@ -2156,175 +2156,118 @@ typedef register_container RegNVICSoftwareTriggerInterrupt_t {
 /** @brief Component definition for @ref NVIC. */
 typedef struct NVIC_t {
     /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_0[4];
+    APE_NVIC_H_uint32_t reserved_0[1];
 
     /** @brief Read the Interrupt Controller Type Register to see the number of interrupt lines that the NVIC supports. */
     RegNVICInterruptControlType_t InterruptControlType;
 
     /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_5[11];
+    APE_NVIC_H_uint32_t reserved_8[2];
 
     /** @brief Use the SysTick Control and Status Register to enable the SysTick features. */
     RegNVICSystickControlAndStatus_t SystickControlAndStatus;
 
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_17[3];
-
     /** @brief Use the SysTick Reload Value Register to specify the start value to load into the current value register when the counter reaches 0. It can be any value between 1 and 0x00FFFFFF. A start value of 0 is possible, but has no effect because the SysTick interrupt and COUNTFLAG are activated when counting from 1 to 0. */
     RegNVICSystickReloadValue_t SystickReloadValue;
 
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_21[3];
-
     /** @brief Use the SysTick Current Value Register to find the current value in the register. */
     RegNVICSystickCurrentValue_t SystickCurrentValue;
-
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_25[3];
 
     /** @brief Use the SysTick Calibration Value Register to enable software to scale to any required speed using divide and multiply. */
     RegNVICSystickCalibrationValue_t SystickCalibrationValue;
 
     /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_29[227];
+    APE_NVIC_H_uint32_t reserved_32[56];
 
     /** @brief Each bit in the register corresponds to one of 32 interrupts. Setting a bit in the Interrupt Set-Enable Register enables the corresponding interrupt. When the enable bit of a pending interrupt is set, the processor activates the interrupt based on its priority. When the enable bit is clear, asserting its interrupt signal pends the interrupt, but it is not possible to activate the interrupt, regardless of its priority. Therefore, a disabled interrupt can serve as a latched general-purpose I/O bit. You can read it and clear it without invoking an interrupt. */
     RegNVICInterruptSetEnable_t InterruptSetEnable;
 
     /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_257[127];
+    APE_NVIC_H_uint32_t reserved_260[31];
 
     /** @brief Each bit in the register corresponds to one of the 32 interrupts. Setting an Interrupt Clear-Enable Register bit disables the corresponding interrupt. */
     RegNVICInterruptClearEnable_t InterruptClearEnable;
 
     /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_385[127];
+    APE_NVIC_H_uint32_t reserved_388[31];
 
     /** @brief Each bit in the register corresponds to one of the 32 interrupts. Setting an Interrupt Set-Pending Register bit pends the corresponding interrupt. */
     RegNVICInterruptSetPending_t InterruptSetPending;
 
     /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_513[127];
+    APE_NVIC_H_uint32_t reserved_516[31];
 
     /** @brief Each bit in the register corresponds to one of the 32 interrupts. Setting an Interrupt Clear-Pending Register bit puts the corresponding pending interrupt in the inactive state. */
     RegNVICInterruptClearPending_t InterruptClearPending;
 
     /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_641[127];
+    APE_NVIC_H_uint32_t reserved_644[31];
 
     /** @brief Read the Active Bit Register to determine which interrupts are active. Each flag in the register corresponds to one of the 32 interrupts. */
     RegNVICActiveBit_t ActiveBit;
 
     /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_769[255];
+    APE_NVIC_H_uint32_t reserved_772[63];
 
     /** @brief Use the Interrupt Priority Registers to assign a priority from 0 to 255 to each of the available interrupts. 0 is the highest priority, and 255 is the lowest. */
     RegNVICInterruptPriority0_t InterruptPriority0;
-
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_1025[3];
 
     /** @brief Use the Interrupt Priority Registers to assign a priority from 0 to 255 to each of the available interrupts. 0 is the highest priority, and 255 is the lowest. */
     RegNVICInterruptPriority1_t InterruptPriority1;
 
     /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_1029[2299];
+    APE_NVIC_H_uint32_t reserved_1032[574];
 
     /** @brief Read the CPU ID Base Register to determine: the ID number of the processor core, the version number of the processor core, the implementation details of the processor core. */
     RegNVICCpuId_t CpuId;
 
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_3329[3];
-
     /** @brief Use the Interrupt Control State Register to: set a pending Non-Maskable Interrupt (NMI), set or clear a pending SVC, set or clear a pending SysTick, check for pending exceptions, check the vector number of the highest priority pended exception, check the vector number of the active exception. */
     RegNVICInterruptControlState_t InterruptControlState;
-
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_3333[3];
 
     /** @brief Use the Vector Table Offset Register to determine: if the vector table is in RAM or code memory, the vector table offset. */
     RegNVICVectorTableOffset_t VectorTableOffset;
 
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_3337[3];
-
     /** @brief the Application Interrupt and Reset Control Register to: determine data endianness, clear all active state information for debug or to recover from a hard failure, execute a system reset, alter the priority grouping position (binary point). */
     RegNVICApplicationInterruptAndResetControl_t ApplicationInterruptAndResetControl;
-
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_3341[3];
 
     /** @brief Use the System Control Register for power-management functions: signal to the system when the processor can enter a low power state, control how the processor enters and exits low power states. */
     RegNVICSystemControl_t SystemControl;
 
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_3345[3];
-
     /** @brief Use the Configuration Control Register to: enable NMI, Hard Fault and FAULTMASK to ignore bus fault, trap divide by zero, and unaligned accesses, enable user access to the Software Trigger Exception Register, control entry to Thread Mode. */
     RegNVICConfigurationControl_t ConfigurationControl;
-
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_3349[3];
 
     /** @brief System handlers are a special class of exception handler that can have their priority set to any of the priority levels. Most can be masked on (enabled) or off (disabled). When disabled, the fault is always treated as a Hard Fault. */
     RegNVICSystemHandlerPriority4_t SystemHandlerPriority4;
 
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_3353[3];
-
     /** @brief System handlers are a special class of exception handler that can have their priority set to any of the priority levels. Most can be masked on (enabled) or off (disabled). When disabled, the fault is always treated as a Hard Fault. */
     RegNVICSystemHandlerPriority8_t SystemHandlerPriority8;
-
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_3357[3];
 
     /** @brief System handlers are a special class of exception handler that can have their priority set to any of the priority levels. Most can be masked on (enabled) or off (disabled). When disabled, the fault is always treated as a Hard Fault. */
     RegNVICSystemHandlerPriority12_t SystemHandlerPriority12;
 
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_3361[3];
-
     /** @brief Use the System Handler Control and State Register to: enable or disable the system handlers, determine the pending status of bus fault, mem manage fault, and SVC, determine the active status of the system handlers. */
     RegNVICSystemHandlerControlAndState_t SystemHandlerControlAndState;
-
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_3365[3];
 
     /** @brief The flags in these registers indicate the causes of local faults. Multiple flags can be set if more than one fault occurs. These register are read/write-clear. This means that they can be read normally, but writing a 1 to any bit clears that bit. */
     RegNVICFaultStatus_t FaultStatus;
 
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_3369[3];
-
     /** @brief Use the Hard Fault Status Register (HFSR) to obtain information about events that activate the Hard Fault handler. */
     RegNVICHardFaultStatus_t HardFaultStatus;
-
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_3373[3];
 
     /** @brief Use the Debug Fault Status Register to monitor: external debug requests, vector catches, data watchpoint match, BKPT instruction execution, halt requests. */
     RegNVICDebugFaultStatus_t DebugFaultStatus;
 
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_3377[3];
-
     /** @brief Use the Memory Manage Fault Address Register to read the address of the location that caused a Memory Manage Fault. */
     RegNVICMemoryManageFaultAddress_t MemoryManageFaultAddress;
 
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_3381[3];
-
     /** @brief Use the Bus Fault Address Register to read the address of the location that generated a Bus Fault. */
     RegNVICBusFaultAddress_t BusFaultAddress;
-
-    /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_3385[3];
 
     /** @brief Use the Auxiliary Fault Status Register (AFSR) to determine additional system fault information to software. The AFSR flags map directly onto the AUXFAULT inputs of the processor, and a single-cycle high level on an external pin causes the corresponding AFSR bit to become latched as one. The bit can only be cleared by writing a one to the corresponding AFSR bit. When an AFSR bit is written or latched as one, an exception does not occur. If you require an exception, you must use an interrupt. */
     RegNVICAuxiliaryFaultAddress_t AuxiliaryFaultAddress;
 
     /** @brief Reserved bytes to pad out data structure. */
-    APE_NVIC_H_uint32_t reserved_3389[451];
+    APE_NVIC_H_uint32_t reserved_3392[112];
 
     /** @brief Use the Software Trigger Interrupt Register to pend an interrupt to trigger. */
     RegNVICSoftwareTriggerInterrupt_t SoftwareTriggerInterrupt;
@@ -2344,144 +2287,68 @@ typedef struct NVIC_t {
             reserved_0[i].setComponentOffset(0x0 + (i * 4));
         }
         InterruptControlType.r32.setComponentOffset(0x4);
-        for(int i = 0; i < 11; i++)
+        for(int i = 0; i < 2; i++)
         {
-            reserved_5[i].setComponentOffset(0x5 + (i * 4));
+            reserved_8[i].setComponentOffset(0x8 + (i * 4));
         }
         SystickControlAndStatus.r32.setComponentOffset(0x10);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_17[i].setComponentOffset(0x11 + (i * 4));
-        }
         SystickReloadValue.r32.setComponentOffset(0x14);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_21[i].setComponentOffset(0x15 + (i * 4));
-        }
         SystickCurrentValue.r32.setComponentOffset(0x18);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_25[i].setComponentOffset(0x19 + (i * 4));
-        }
         SystickCalibrationValue.r32.setComponentOffset(0x1c);
-        for(int i = 0; i < 227; i++)
+        for(int i = 0; i < 56; i++)
         {
-            reserved_29[i].setComponentOffset(0x1d + (i * 4));
+            reserved_32[i].setComponentOffset(0x20 + (i * 4));
         }
         InterruptSetEnable.r32.setComponentOffset(0x100);
-        for(int i = 0; i < 127; i++)
+        for(int i = 0; i < 31; i++)
         {
-            reserved_257[i].setComponentOffset(0x101 + (i * 4));
+            reserved_260[i].setComponentOffset(0x104 + (i * 4));
         }
         InterruptClearEnable.r32.setComponentOffset(0x180);
-        for(int i = 0; i < 127; i++)
+        for(int i = 0; i < 31; i++)
         {
-            reserved_385[i].setComponentOffset(0x181 + (i * 4));
+            reserved_388[i].setComponentOffset(0x184 + (i * 4));
         }
         InterruptSetPending.r32.setComponentOffset(0x200);
-        for(int i = 0; i < 127; i++)
+        for(int i = 0; i < 31; i++)
         {
-            reserved_513[i].setComponentOffset(0x201 + (i * 4));
+            reserved_516[i].setComponentOffset(0x204 + (i * 4));
         }
         InterruptClearPending.r32.setComponentOffset(0x280);
-        for(int i = 0; i < 127; i++)
+        for(int i = 0; i < 31; i++)
         {
-            reserved_641[i].setComponentOffset(0x281 + (i * 4));
+            reserved_644[i].setComponentOffset(0x284 + (i * 4));
         }
         ActiveBit.r32.setComponentOffset(0x300);
-        for(int i = 0; i < 255; i++)
+        for(int i = 0; i < 63; i++)
         {
-            reserved_769[i].setComponentOffset(0x301 + (i * 4));
+            reserved_772[i].setComponentOffset(0x304 + (i * 4));
         }
         InterruptPriority0.r32.setComponentOffset(0x400);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_1025[i].setComponentOffset(0x401 + (i * 4));
-        }
         InterruptPriority1.r32.setComponentOffset(0x404);
-        for(int i = 0; i < 2299; i++)
+        for(int i = 0; i < 574; i++)
         {
-            reserved_1029[i].setComponentOffset(0x405 + (i * 4));
+            reserved_1032[i].setComponentOffset(0x408 + (i * 4));
         }
         CpuId.r32.setComponentOffset(0xd00);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3329[i].setComponentOffset(0xd01 + (i * 4));
-        }
         InterruptControlState.r32.setComponentOffset(0xd04);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3333[i].setComponentOffset(0xd05 + (i * 4));
-        }
         VectorTableOffset.r32.setComponentOffset(0xd08);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3337[i].setComponentOffset(0xd09 + (i * 4));
-        }
         ApplicationInterruptAndResetControl.r32.setComponentOffset(0xd0c);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3341[i].setComponentOffset(0xd0d + (i * 4));
-        }
         SystemControl.r32.setComponentOffset(0xd10);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3345[i].setComponentOffset(0xd11 + (i * 4));
-        }
         ConfigurationControl.r32.setComponentOffset(0xd14);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3349[i].setComponentOffset(0xd15 + (i * 4));
-        }
         SystemHandlerPriority4.r32.setComponentOffset(0xd18);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3353[i].setComponentOffset(0xd19 + (i * 4));
-        }
         SystemHandlerPriority8.r32.setComponentOffset(0xd1c);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3357[i].setComponentOffset(0xd1d + (i * 4));
-        }
         SystemHandlerPriority12.r32.setComponentOffset(0xd20);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3361[i].setComponentOffset(0xd21 + (i * 4));
-        }
         SystemHandlerControlAndState.r32.setComponentOffset(0xd24);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3365[i].setComponentOffset(0xd25 + (i * 4));
-        }
         FaultStatus.r32.setComponentOffset(0xd28);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3369[i].setComponentOffset(0xd29 + (i * 4));
-        }
         HardFaultStatus.r32.setComponentOffset(0xd2c);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3373[i].setComponentOffset(0xd2d + (i * 4));
-        }
         DebugFaultStatus.r32.setComponentOffset(0xd30);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3377[i].setComponentOffset(0xd31 + (i * 4));
-        }
         MemoryManageFaultAddress.r32.setComponentOffset(0xd34);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3381[i].setComponentOffset(0xd35 + (i * 4));
-        }
         BusFaultAddress.r32.setComponentOffset(0xd38);
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3385[i].setComponentOffset(0xd39 + (i * 4));
-        }
         AuxiliaryFaultAddress.r32.setComponentOffset(0xd3c);
-        for(int i = 0; i < 451; i++)
+        for(int i = 0; i < 112; i++)
         {
-            reserved_3389[i].setComponentOffset(0xd3d + (i * 4));
+            reserved_3392[i].setComponentOffset(0xd40 + (i * 4));
         }
         SoftwareTriggerInterrupt.r32.setComponentOffset(0xf00);
     }
@@ -2492,144 +2359,68 @@ typedef struct NVIC_t {
             reserved_0[i].print();
         }
         InterruptControlType.print();
-        for(int i = 0; i < 11; i++)
+        for(int i = 0; i < 2; i++)
         {
-            reserved_5[i].print();
+            reserved_8[i].print();
         }
         SystickControlAndStatus.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_17[i].print();
-        }
         SystickReloadValue.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_21[i].print();
-        }
         SystickCurrentValue.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_25[i].print();
-        }
         SystickCalibrationValue.print();
-        for(int i = 0; i < 227; i++)
+        for(int i = 0; i < 56; i++)
         {
-            reserved_29[i].print();
+            reserved_32[i].print();
         }
         InterruptSetEnable.print();
-        for(int i = 0; i < 127; i++)
+        for(int i = 0; i < 31; i++)
         {
-            reserved_257[i].print();
+            reserved_260[i].print();
         }
         InterruptClearEnable.print();
-        for(int i = 0; i < 127; i++)
+        for(int i = 0; i < 31; i++)
         {
-            reserved_385[i].print();
+            reserved_388[i].print();
         }
         InterruptSetPending.print();
-        for(int i = 0; i < 127; i++)
+        for(int i = 0; i < 31; i++)
         {
-            reserved_513[i].print();
+            reserved_516[i].print();
         }
         InterruptClearPending.print();
-        for(int i = 0; i < 127; i++)
+        for(int i = 0; i < 31; i++)
         {
-            reserved_641[i].print();
+            reserved_644[i].print();
         }
         ActiveBit.print();
-        for(int i = 0; i < 255; i++)
+        for(int i = 0; i < 63; i++)
         {
-            reserved_769[i].print();
+            reserved_772[i].print();
         }
         InterruptPriority0.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_1025[i].print();
-        }
         InterruptPriority1.print();
-        for(int i = 0; i < 2299; i++)
+        for(int i = 0; i < 574; i++)
         {
-            reserved_1029[i].print();
+            reserved_1032[i].print();
         }
         CpuId.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3329[i].print();
-        }
         InterruptControlState.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3333[i].print();
-        }
         VectorTableOffset.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3337[i].print();
-        }
         ApplicationInterruptAndResetControl.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3341[i].print();
-        }
         SystemControl.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3345[i].print();
-        }
         ConfigurationControl.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3349[i].print();
-        }
         SystemHandlerPriority4.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3353[i].print();
-        }
         SystemHandlerPriority8.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3357[i].print();
-        }
         SystemHandlerPriority12.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3361[i].print();
-        }
         SystemHandlerControlAndState.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3365[i].print();
-        }
         FaultStatus.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3369[i].print();
-        }
         HardFaultStatus.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3373[i].print();
-        }
         DebugFaultStatus.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3377[i].print();
-        }
         MemoryManageFaultAddress.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3381[i].print();
-        }
         BusFaultAddress.print();
-        for(int i = 0; i < 3; i++)
-        {
-            reserved_3385[i].print();
-        }
         AuxiliaryFaultAddress.print();
-        for(int i = 0; i < 451; i++)
+        for(int i = 0; i < 112; i++)
         {
-            reserved_3389[i].print();
+            reserved_3392[i].print();
         }
         SoftwareTriggerInterrupt.print();
     }
@@ -2653,7 +2444,7 @@ extern volatile NVIC_t NVIC;
 #undef BITFIELD_END
 
 #ifndef CXX_SIMULATOR
-_Static_assert(sizeof(NVIC_t) == 15376, "sizeof(NVIC_t) must be 15376");
+_Static_assert(sizeof(NVIC_t) == 3844, "sizeof(NVIC_t) must be 3844");
 #endif
 
 #endif /* !APE_NVIC_H */

--- a/ipxact/APE.xml
+++ b/ipxact/APE.xml
@@ -18,7 +18,7 @@
                 <ipxact:usage>register</ipxact:usage>
                 <ipxact:volatile>false</ipxact:volatile>
             </ipxact:addressBlock>
-            <ipxact:addressUnitBits>32</ipxact:addressUnitBits>
+            <ipxact:addressUnitBits>8</ipxact:addressUnitBits>
         </ipxact:memoryMap>
 
         <!-- APE Registers: 0x6020_0000 to  6020_8FFF-->

--- a/ipxact/NVIC.xml
+++ b/ipxact/NVIC.xml
@@ -943,7 +943,7 @@
                     </ipxact:field>
                 </ipxact:register>
             </ipxact:addressBlock>
-            <ipxact:addressUnitBits>32</ipxact:addressUnitBits>
+            <ipxact:addressUnitBits>8</ipxact:addressUnitBits>
         </ipxact:memoryMap>
     </ipxact:memoryMaps>
 </ipxact:component>

--- a/simulator/APE_NVIC.cpp
+++ b/simulator/APE_NVIC.cpp
@@ -10,7 +10,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// @copyright Copyright (c) 2018, Evan Lojewski
+/// @copyright Copyright (c) 2020, Evan Lojewski
 /// @cond
 ///
 /// All rights reserved.

--- a/simulator/APE_NVIC_sim.cpp
+++ b/simulator/APE_NVIC_sim.cpp
@@ -10,7 +10,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// @copyright Copyright (c) 2018, Evan Lojewski
+/// @copyright Copyright (c) 2020, Evan Lojewski
 /// @cond
 ///
 /// All rights reserved.

--- a/simulator/HAL.cpp
+++ b/simulator/HAL.cpp
@@ -54,6 +54,8 @@
 #include <bcm5719_SHM_CHANNEL3.h>
 #include <bcm5719_GEN.h>
 
+#include <APE_NVIC.h>
+
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -350,6 +352,9 @@ bool initHAL(const char *pci_path, int wanted_function)
     init_bcm5719_SHM_CHANNEL2_sim(&APEBase[0x4b00]);
     init_bcm5719_SHM_CHANNEL3();
     init_bcm5719_SHM_CHANNEL3_sim(&APEBase[0x4c00]);
+
+    init_APE_NVIC();
+    init_APE_NVIC_sim(0);
 
     return true;
 }

--- a/utils/bcmregtool/main.cpp
+++ b/utils/bcmregtool/main.cpp
@@ -47,6 +47,7 @@
 #include <APE.h>
 #include <APE_APE_PERI.h>
 #include <APE_DEVICE.h>
+#include <APE_NVIC.h>
 #include <HAL.hpp>
 #include <MII.h>
 #include <NVRam.h>
@@ -355,6 +356,8 @@ int main(int argc, char const *argv[])
     parser.add_option("-n", "--network").dest("network").set_default("0").action("store_true").help("Print network information / status.");
 
     parser.add_option("--nvm").dest("nvm").set_default("0").action("store_true").help("Print NVM registers");
+
+    parser.add_option("--nvic").dest("nvic").set_default("0").action("store_true").help("Print NVIC registers");
 
     parser.add_option("--unlock").dest("unlock").set_default("0").action("store_true").help("Unlock NVM and APE registers");
 
@@ -761,6 +764,13 @@ int main(int argc, char const *argv[])
     if (options.get("nvm"))
     {
         NVM.print();
+
+        exit(0);
+    }
+
+    if (options.get("nvic"))
+    {
+        NVIC.print();
 
         exit(0);
     }


### PR DESCRIPTION
- Regenerate headers with correct address
- Enable NVIC access using the HAL
- Enable dumping NVIC registers using bcmregtool.