### PR TITLE
ape: Initialize the network PHY after a GRC reset.

### DIFF
--- a/ape/include/ape_main.h
+++ b/ape/include/ape_main.h
@@ -88,5 +88,6 @@ void __attribute__((interrupt)) IRQ_RxPacketEven(void);
 void __attribute__((interrupt)) IRQ_RxPacketOdd(void);
 void __attribute__((interrupt)) IRQ_RMU(void);
 void __attribute__((interrupt)) IRQ_VoltageSource(void);
+void __attribute__((interrupt)) IRQ_PowerStatusChanged(void);
 
 #endif /* APE_MAIN_H */


### PR DESCRIPTION
This change also minimizes a race condition in the event that a
GRC reset happened before the Network_checkEnableState check,
the firmware could have issue multiple reload commands.
Check for this case and skip the APE mode change reset as a
reset will immediately follow.