### PR TITLE
stage1: Ensure PciConfig is initialized to enable APE writes from the…

### DIFF
--- a/stage1/init_hw.c
+++ b/stage1/init_hw.c
@@ -176,7 +176,7 @@ void __attribute__((noinline)) zero_bss(void)
 #endif
 }
 
-void early_init_hw(void)
+void early_init_hw(volatile DEVICE_t *device)
 {
     zero_bss();
 
@@ -187,6 +187,13 @@ void early_init_hw(void)
     memset((void *)&TXMBUF, 0, REG_TXMBUF_SIZE);
     memset((void *)&SDBCACHE, 0, REG_SDBCACHE_SIZE);
 #endif
+
+    RegDEVICEPciState_t PciState;
+    PciState.r32 = device->PciState.r32;
+    PciState.bits.APEControlRegisterWriteEnable = 1;
+    PciState.bits.APESharedMemoryWriteEnable = 1;
+    PciState.bits.APEProgramSpaceWriteEnable = 1;
+    device->PciState.r32 = PciState.r32;
 }
 
 void init_mac(const NVRAMContents_t *nvram)

--- a/stage1/main.c
+++ b/stage1/main.c
@@ -182,7 +182,7 @@ int main()
     }
 
     // Perform early initialization
-    early_init_hw();
+    early_init_hw(&DEVICE);
 
     reportStatus(STATUS_MAIN, 1);
 

--- a/stage1/stage1.h
+++ b/stage1/stage1.h
@@ -61,7 +61,7 @@
 #include <bcm5719_DEVICE.h>
 #endif
 
-void early_init_hw(void);
+void early_init_hw(volatile DEVICE_t *device);
 void load_nvm_config(volatile DEVICE_t* device, const NVRAMContents_t *nvram);
 void init_hw(volatile DEVICE_t* device);
 


### PR DESCRIPTION
… host.

This fixes an issue on FreeBSD that resulted in the following printout:
    bge1: APE lock 1 request failed! request = 0x8404[0x0002], status = 0x8424[0x0000]