### PR TITLE
ape: Fix a possible race condition where MII contention could exist.

### DIFF
--- a/libs/Network/include/Network.h
+++ b/libs/Network/include/Network.h
@@ -112,6 +112,7 @@ void Network_resetRX(NetworkPort_t *port, reload_type_t reset_phy);
 void Network_checkPortState(NetworkPort_t *port);
 bool Network_updatePortState(NetworkPort_t *port);
 bool Network_checkEnableState(NetworkPort_t *port);
+void Network_setEnableState(NetworkPort_t *port);
 
 bool Network_isLinkUp(NetworkPort_t *port);
 void Network_resetLink(NetworkPort_t *port);


### PR DESCRIPTION
This ensure the APE locks the MII interface before accessing it to avoid collisions with the host.