### PR TITLE
ape: Handle host driver events to improve FreeBSD compatibility.

### DIFF
--- a/include/APE_SHM.h
+++ b/include/APE_SHM.h
@@ -10,7 +10,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// @copyright Copyright (c) 2020, Evan Lojewski
+/// @copyright Copyright (c) 2021, Evan Lojewski
 /// @cond
 ///
 /// All rights reserved.
@@ -456,6 +456,31 @@ typedef register_container RegSHM4028_t {
     }
 #endif /* CXX_SIMULATOR */
 } RegSHM4028_t;
+
+#define REG_SHM_DRIVER_BUFFER ((volatile APE_SHM_H_uint32_t*)0x60220030) /* Communication channel between the host driver and the APE. */
+/** @brief Register definition for @ref SHM_t.DriverBuffer. */
+typedef register_container RegSHMDriverBuffer_t {
+    /** @brief 32bit direct register access. */
+    APE_SHM_H_uint32_t r32;
+#ifdef CXX_SIMULATOR
+    /** @brief Register name for use with the simulator. */
+    const char* getName(void) { return "DriverBuffer"; }
+
+    /** @brief Print register value. */
+    void print(void) { r32.print(); }
+
+    RegSHMDriverBuffer_t()
+    {
+        /** @brief constructor for @ref SHM_t.DriverBuffer. */
+        r32.setName("DriverBuffer");
+    }
+    RegSHMDriverBuffer_t& operator=(const RegSHMDriverBuffer_t& other)
+    {
+        r32 = other.r32;
+        return *this;
+    }
+#endif /* CXX_SIMULATOR */
+} RegSHMDriverBuffer_t;
 
 #define REG_SHM_LOADER_COMMAND ((volatile APE_SHM_H_uint32_t*)0x60220038) /* Command sent when using the the APE loader. Zero once handled. */
 #define     SHM_LOADER_COMMAND_COMMAND_SHIFT 0u
@@ -1590,7 +1615,10 @@ typedef struct SHM_t {
     RegSHM4028_t _4028;
 
     /** @brief Reserved bytes to pad out data structure. */
-    APE_SHM_H_uint32_t reserved_44[3];
+    APE_SHM_H_uint32_t reserved_44[1];
+
+    /** @brief Communication channel between the host driver and the APE. */
+    RegSHMDriverBuffer_t DriverBuffer[2];
 
     /** @brief Command sent when using the the APE loader. Zero once handled. */
     RegSHMLoaderCommand_t LoaderCommand;
@@ -1736,9 +1764,13 @@ typedef struct SHM_t {
         SegMessageBufferLength.r32.setComponentOffset(0x20);
         _4024.r32.setComponentOffset(0x24);
         _4028.r32.setComponentOffset(0x28);
-        for(int i = 0; i < 3; i++)
+        for(int i = 0; i < 1; i++)
         {
             reserved_44[i].setComponentOffset(0x2c + (i * 4));
+        }
+        for(int i = 0; i < 2; i++)
+        {
+            DriverBuffer[i].r32.setComponentOffset(0x30 + (i * 4));
         }
         LoaderCommand.r32.setComponentOffset(0x38);
         LoaderArg0.r32.setComponentOffset(0x3c);
@@ -1821,9 +1853,13 @@ typedef struct SHM_t {
         SegMessageBufferLength.print();
         _4024.print();
         _4028.print();
-        for(int i = 0; i < 3; i++)
+        for(int i = 0; i < 1; i++)
         {
             reserved_44[i].print();
+        }
+        for(int i = 0; i < 2; i++)
+        {
+            DriverBuffer[i].print();
         }
         LoaderCommand.print();
         LoaderArg0.print();

--- a/include/APE_SHM1.h
+++ b/include/APE_SHM1.h
@@ -10,7 +10,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// @copyright Copyright (c) 2020, Evan Lojewski
+/// @copyright Copyright (c) 2021, Evan Lojewski
 /// @cond
 ///
 /// All rights reserved.
@@ -92,6 +92,7 @@ typedef uint32_t APE_SHM1_H_uint32_t;
 #define REG_SHM1_SEG_MESSAGE_BUFFER_LENGTH ((volatile APE_SHM1_H_uint32_t*)0x60221020) /* Specifies the size of the scratchpad area in bytes. */
 #define REG_SHM1_4024 ((volatile APE_SHM1_H_uint32_t*)0x60221024) /* Unknown. Bootcode related. */
 #define REG_SHM1_4028 ((volatile APE_SHM1_H_uint32_t*)0x60221028) /* Unknown. Bootcode related. */
+#define REG_SHM1_DRIVER_BUFFER ((volatile APE_SHM1_H_uint32_t*)0x60221030) /* Communication channel between the host driver and the APE. */
 #define REG_SHM1_LOADER_COMMAND ((volatile APE_SHM1_H_uint32_t*)0x60221038) /* Command sent when using the the APE loader. Zero once handled. */
 #define REG_SHM1_LOADER_ARG0 ((volatile APE_SHM1_H_uint32_t*)0x6022103c) /* Argument 0 for the APE loader. */
 #define REG_SHM1_LOADER_ARG1 ((volatile APE_SHM1_H_uint32_t*)0x60221040) /* Argument 1 for the APE loader. */

--- a/include/APE_SHM2.h
+++ b/include/APE_SHM2.h
@@ -10,7 +10,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// @copyright Copyright (c) 2020, Evan Lojewski
+/// @copyright Copyright (c) 2021, Evan Lojewski
 /// @cond
 ///
 /// All rights reserved.
@@ -92,6 +92,7 @@ typedef uint32_t APE_SHM2_H_uint32_t;
 #define REG_SHM2_SEG_MESSAGE_BUFFER_LENGTH ((volatile APE_SHM2_H_uint32_t*)0x60222020) /* Specifies the size of the scratchpad area in bytes. */
 #define REG_SHM2_4024 ((volatile APE_SHM2_H_uint32_t*)0x60222024) /* Unknown. Bootcode related. */
 #define REG_SHM2_4028 ((volatile APE_SHM2_H_uint32_t*)0x60222028) /* Unknown. Bootcode related. */
+#define REG_SHM2_DRIVER_BUFFER ((volatile APE_SHM2_H_uint32_t*)0x60222030) /* Communication channel between the host driver and the APE. */
 #define REG_SHM2_LOADER_COMMAND ((volatile APE_SHM2_H_uint32_t*)0x60222038) /* Command sent when using the the APE loader. Zero once handled. */
 #define REG_SHM2_LOADER_ARG0 ((volatile APE_SHM2_H_uint32_t*)0x6022203c) /* Argument 0 for the APE loader. */
 #define REG_SHM2_LOADER_ARG1 ((volatile APE_SHM2_H_uint32_t*)0x60222040) /* Argument 1 for the APE loader. */

--- a/include/APE_SHM3.h
+++ b/include/APE_SHM3.h
@@ -10,7 +10,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// @copyright Copyright (c) 2020, Evan Lojewski
+/// @copyright Copyright (c) 2021, Evan Lojewski
 /// @cond
 ///
 /// All rights reserved.
@@ -92,6 +92,7 @@ typedef uint32_t APE_SHM3_H_uint32_t;
 #define REG_SHM3_SEG_MESSAGE_BUFFER_LENGTH ((volatile APE_SHM3_H_uint32_t*)0x60223020) /* Specifies the size of the scratchpad area in bytes. */
 #define REG_SHM3_4024 ((volatile APE_SHM3_H_uint32_t*)0x60223024) /* Unknown. Bootcode related. */
 #define REG_SHM3_4028 ((volatile APE_SHM3_H_uint32_t*)0x60223028) /* Unknown. Bootcode related. */
+#define REG_SHM3_DRIVER_BUFFER ((volatile APE_SHM3_H_uint32_t*)0x60223030) /* Communication channel between the host driver and the APE. */
 #define REG_SHM3_LOADER_COMMAND ((volatile APE_SHM3_H_uint32_t*)0x60223038) /* Command sent when using the the APE loader. Zero once handled. */
 #define REG_SHM3_LOADER_ARG0 ((volatile APE_SHM3_H_uint32_t*)0x6022303c) /* Argument 0 for the APE loader. */
 #define REG_SHM3_LOADER_ARG1 ((volatile APE_SHM3_H_uint32_t*)0x60223040) /* Argument 1 for the APE loader. */

--- a/include/bcm5719_SHM.h
+++ b/include/bcm5719_SHM.h
@@ -10,7 +10,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// @copyright Copyright (c) 2020, Evan Lojewski
+/// @copyright Copyright (c) 2021, Evan Lojewski
 /// @cond
 ///
 /// All rights reserved.
@@ -456,6 +456,31 @@ typedef register_container RegSHM4028_t {
     }
 #endif /* CXX_SIMULATOR */
 } RegSHM4028_t;
+
+#define REG_SHM_DRIVER_BUFFER ((volatile BCM5719_SHM_H_uint32_t*)0xc0014030) /* Communication channel between the host driver and the APE. */
+/** @brief Register definition for @ref SHM_t.DriverBuffer. */
+typedef register_container RegSHMDriverBuffer_t {
+    /** @brief 32bit direct register access. */
+    BCM5719_SHM_H_uint32_t r32;
+#ifdef CXX_SIMULATOR
+    /** @brief Register name for use with the simulator. */
+    const char* getName(void) { return "DriverBuffer"; }
+
+    /** @brief Print register value. */
+    void print(void) { r32.print(); }
+
+    RegSHMDriverBuffer_t()
+    {
+        /** @brief constructor for @ref SHM_t.DriverBuffer. */
+        r32.setName("DriverBuffer");
+    }
+    RegSHMDriverBuffer_t& operator=(const RegSHMDriverBuffer_t& other)
+    {
+        r32 = other.r32;
+        return *this;
+    }
+#endif /* CXX_SIMULATOR */
+} RegSHMDriverBuffer_t;
 
 #define REG_SHM_LOADER_COMMAND ((volatile BCM5719_SHM_H_uint32_t*)0xc0014038) /* Command sent when using the the APE loader. Zero once handled. */
 #define     SHM_LOADER_COMMAND_COMMAND_SHIFT 0u
@@ -1590,7 +1615,10 @@ typedef struct SHM_t {
     RegSHM4028_t _4028;
 
     /** @brief Reserved bytes to pad out data structure. */
-    BCM5719_SHM_H_uint32_t reserved_44[3];
+    BCM5719_SHM_H_uint32_t reserved_44[1];
+
+    /** @brief Communication channel between the host driver and the APE. */
+    RegSHMDriverBuffer_t DriverBuffer[2];
 
     /** @brief Command sent when using the the APE loader. Zero once handled. */
     RegSHMLoaderCommand_t LoaderCommand;
@@ -1736,9 +1764,13 @@ typedef struct SHM_t {
         SegMessageBufferLength.r32.setComponentOffset(0x20);
         _4024.r32.setComponentOffset(0x24);
         _4028.r32.setComponentOffset(0x28);
-        for(int i = 0; i < 3; i++)
+        for(int i = 0; i < 1; i++)
         {
             reserved_44[i].setComponentOffset(0x2c + (i * 4));
+        }
+        for(int i = 0; i < 2; i++)
+        {
+            DriverBuffer[i].r32.setComponentOffset(0x30 + (i * 4));
         }
         LoaderCommand.r32.setComponentOffset(0x38);
         LoaderArg0.r32.setComponentOffset(0x3c);
@@ -1821,9 +1853,13 @@ typedef struct SHM_t {
         SegMessageBufferLength.print();
         _4024.print();
         _4028.print();
-        for(int i = 0; i < 3; i++)
+        for(int i = 0; i < 1; i++)
         {
             reserved_44[i].print();
+        }
+        for(int i = 0; i < 2; i++)
+        {
+            DriverBuffer[i].print();
         }
         LoaderCommand.print();
         LoaderArg0.print();

--- a/ipxact/SHM.xml
+++ b/ipxact/SHM.xml
@@ -157,6 +157,15 @@
                     <ipxact:volatile>true</ipxact:volatile>
                 </ipxact:register>
                 <ipxact:register>
+                    <ipxact:name>Driver_Buffer</ipxact:name>
+                    <ipxact:description>Communication channel between the host driver and the APE.</ipxact:description>
+                    <ipxact:dim>2</ipxact:dim>
+                    <ipxact:addressOffset>0x30</ipxact:addressOffset>
+                    <!-- LINK: registerDefinitionGroup: see 6.11.3, Register definition group -->
+                    <ipxact:size>32</ipxact:size>
+                    <ipxact:volatile>true</ipxact:volatile>
+                </ipxact:register>
+                <ipxact:register>
                     <ipxact:name>Loader_Command</ipxact:name>
                     <ipxact:description>Command sent when using the the APE loader. Zero once handled.</ipxact:description>
                     <ipxact:addressOffset>0x38</ipxact:addressOffset>

--- a/libs/APE/ape.c
+++ b/libs/APE/ape.c
@@ -127,6 +127,37 @@ void APE_releaseLock(void)
     }
 }
 
+void APE_aquireMemLock(void)
+{
+    RegAPE_PERIPerLockRequestMem_t lock_req;
+    lock_req.r32 = 0;
+#ifdef __arm__ /* APE */
+    lock_req.bits.APE = 1;
+#else
+    lock_req.bits.Bootcode = 1;
+#endif
+
+    APE_PERI.PerLockRequestMem.r32 = lock_req.r32;
+    do
+    {
+        // spin
+    } while (lock_req.r32 != APE_PERI.PerLockGrantMem.r32);
+    return;
+}
+
+void APE_releaseMemLock(void)
+{
+    RegAPE_PERIPerLockGrantMem_t lock_release;
+    lock_release.r32 = 0;
+#ifdef __arm__ /* APE */
+    lock_release.bits.APE = 1;
+#else
+    lock_release.bits.Bootcode = 1;
+#endif
+
+    APE_PERI.PerLockGrantMem.r32 = lock_release.r32;
+}
+
 void APE_releaseAllLocks(void)
 {
     RegAPE_PERIPerLockGrantPhy0_t lock_release;

--- a/libs/APE/include/APE.h
+++ b/libs/APE/include/APE.h
@@ -49,6 +49,10 @@ void APE_aquireLock(void);
 
 void APE_releaseLock(void);
 
+void APE_aquireMemLock(void);
+
+void APE_releaseMemLock(void);
+
 void APE_releaseAllLocks(void);
 
 #endif /* LIBS_APE_H */

--- a/simulator/bcm5719_SHM.cpp
+++ b/simulator/bcm5719_SHM.cpp
@@ -10,7 +10,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// @copyright Copyright (c) 2020, Evan Lojewski
+/// @copyright Copyright (c) 2021, Evan Lojewski
 /// @cond
 ///
 /// All rights reserved.
@@ -68,6 +68,8 @@ void init_bcm5719_SHM(void)
     /** @brief Bitmap for @ref SHM_t.4024. */
 
     /** @brief Bitmap for @ref SHM_t.4028. */
+
+    /** @brief Bitmap for @ref SHM_t.DriverBuffer. */
 
     /** @brief Bitmap for @ref SHM_t.LoaderCommand. */
 

--- a/simulator/bcm5719_SHM_sim.cpp
+++ b/simulator/bcm5719_SHM_sim.cpp
@@ -10,7 +10,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// @copyright Copyright (c) 2020, Evan Lojewski
+/// @copyright Copyright (c) 2021, Evan Lojewski
 /// @cond
 ///
 /// All rights reserved.
@@ -126,11 +126,18 @@ void init_bcm5719_SHM_sim(void *base)
     SHM._4028.r32.installReadCallback(read_from_ram, (uint8_t *)base);
     SHM._4028.r32.installWriteCallback(write_to_ram, (uint8_t *)base);
 
-    for(int i = 0; i < 3; i++)
+    for(int i = 0; i < 1; i++)
     {
         SHM.reserved_44[i].installReadCallback(read_from_ram, (uint8_t *)base);
         SHM.reserved_44[i].installWriteCallback(write_to_ram, (uint8_t *)base);
     }
+    /** @brief Bitmap for @ref SHM_t.DriverBuffer. */
+    for(int i = 0; i < 2; i++)
+    {
+        SHM.DriverBuffer[i].r32.installReadCallback(read_from_ram, (uint8_t *)base);
+        SHM.DriverBuffer[i].r32.installWriteCallback(write_to_ram, (uint8_t *)base);
+    }
+
     /** @brief Bitmap for @ref SHM_t.LoaderCommand. */
     SHM.LoaderCommand.r32.installReadCallback(read_from_ram, (uint8_t *)base);
     SHM.LoaderCommand.r32.installWriteCallback(write_to_ram, (uint8_t *)base);


### PR DESCRIPTION
This silences the following FreeBSD message:
    bge0: APE event 0x00020510 send timed out